### PR TITLE
2to3 available - passes tests with py25-27,py31-32,pypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
+import sys
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
 
+kwargs = {}
+if sys.version_info >= (3, ):
+    kwargs['use_2to3'] = True
 setup(
     name='itsdangerous',
     author='Armin Ronacher',
@@ -15,6 +19,14 @@ setup(
     zip_safe=False,
     classifiers=[
         'License :: OSI Approved :: BSD License',
-        'Programming Language :: Python'
-    ]
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
+    ],
+    **kwargs
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist=py25,py26,py27,py31,py32,pypy
+
+[testenv]
+changedir=envtmpdir
+commands={envpython} {toxinidir}/tests.py
+
+[testenv:py25]
+deps=simplejson
+
+[testenv:py31]
+commands=
+    2to3 -w -n -o {envtmpdir} --no-diffs {toxinidir}/tests.py
+    {envpython} {envtmpdir}/tests.py
+
+[testenv:py32]
+commands=
+    2to3 -w -n -o {envtmpdir} --no-diffs {toxinidir}/tests.py
+    {envpython} {envtmpdir}/tests.py


### PR DESCRIPTION
What the title says.

A subtle difference that may affect Python 2 users: In Python 3, `json.loads()` accepts (unicode) `str` only, and some serializers pack objects into only `bytes` (e.g. `pickle`) .  So `itsdangerous` tries to negotiate with the string type serializers are using; and in that case, `latin1` encoding is assumed.
