### PR TITLE
''.encode(errors=) is missing on 2.6

### DIFF
--- a/itsdangerous.py
+++ b/itsdangerous.py
@@ -58,7 +58,7 @@ EPOCH = 1293840000
 
 def want_bytes(s, encoding='utf-8', errors='strict'):
     if isinstance(s, text_type):
-        s = s.encode(encoding, errors=errors)
+        s = s.encode(encoding, errors)
     return s
 
 

--- a/tests.py
+++ b/tests.py
@@ -21,6 +21,12 @@ else:
         return value
 
 
+class UtilityTestCase(unittest.TestCase):
+    def test_want_bytes(self):
+        self.assertEqual(want_bytes(b"foobar"), b"foobar")
+        self.assertEqual(want_bytes(u"foobar"), b"foobar")
+
+
 class SerializerTestCase(unittest.TestCase):
     serializer_class = idmod.Serializer
 


### PR DESCRIPTION
`''.encode()` does not have an errors keyword argument in 2.6. I've created a test case that demonstrates the issue and fixed the issue itself.
