### PR TITLE
include license and tests in source tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include LICENSE
+include CHANGES
+include tests.py


### PR DESCRIPTION
I'd like to package itsdangerous for Fedora, but the source tarball on PyPI is missing a copy of the license. It's a requirement of the license itself that the license text be included with the source, and I need to ship it with the package as well:

https://fedoraproject.org/wiki/Packaging:LicensingGuidelines#License_Text

This patch adds a MANIFEST.in to bundle LICENSE in the source tarball.

I also added the tests, because I'd like to run them during package build to make sure everything is working.
