### PR TITLE
JWT Serializer sets default media type header

### DIFF
--- a/itsdangerous.py
+++ b/itsdangerous.py
@@ -666,17 +666,22 @@ class JSONWebSignatureSerializer(Serializer):
 
     #: The default algorithm to use for signature generation
     default_algorithm = 'HS256'
+    default_media_type = 'JWT'
 
     default_serializer = compact_json
 
     def __init__(self, secret_key, salt=None, serializer=None,
-                 signer=None, signer_kwargs=None, algorithm_name=None):
+                 signer=None, signer_kwargs=None, algorithm_name=None,
+                 media_type=None):
         Serializer.__init__(self, secret_key, salt, serializer,
                             signer, signer_kwargs)
         if algorithm_name is None:
             algorithm_name = self.default_algorithm
         self.algorithm_name = algorithm_name
         self.algorithm = self.make_algorithm(algorithm_name)
+        if media_type is None:
+            media_type = self.default_media_type
+        self.media_type = media_type
 
     def load_payload(self, payload, return_header=False):
         payload = want_bytes(payload)
@@ -730,6 +735,7 @@ class JSONWebSignatureSerializer(Serializer):
     def make_header(self, header_fields):
         header = header_fields.copy() if header_fields else {}
         header['alg'] = self.algorithm_name
+        header['typ'] = self.media_type
         return header
 
     def dumps(self, obj, salt=None, header_fields=None):

--- a/tests.py
+++ b/tests.py
@@ -179,11 +179,12 @@ class JSONWebSignatureSerializerTestCase(SerializerTestCase):
     def test_decode_return_header(self):
         secret_key = 'predictable-key'
         value = u'hello'
-        header = {"typ": "dummy"}
+        header = {"cty": "dummy"}
 
         s = self.make_serializer(secret_key)
         full_header = header.copy()
         full_header['alg'] = s.algorithm_name
+        full_header['typ'] = s.media_type
 
         ts = s.dumps(value, header_fields=header)
         loaded, loaded_header = s.loads(ts, return_header=True)
@@ -222,6 +223,19 @@ class JSONWebSignatureSerializerTestCase(SerializerTestCase):
             self.assertEqual(s.load_payload(e.payload), value)
         else:
             self.fail('Did not get algorithm mismatch')
+
+    def test_custom_media_type(self):
+        secret_key = 'predictable-key'
+        media_type = 'example'
+
+        s = self.make_serializer(secret_key, media_type=media_type)
+        full_header = {
+            'alg': s.algorithm_name,
+            'typ': s.media_type,
+        }
+        ts = s.dumps({})
+        loaded, loaded_header = s.loads(ts, return_header=True)
+        self.assertEqual(loaded_header, full_header)
 
 
 class TimedJSONWebSignatureSerializerTest(unittest.TestCase):


### PR DESCRIPTION
The JWT IETF draft specifies that there can be a `typ` [header](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-5.1) to declare the media type of the JWT. The header is optional but is useful to indicate that the object is a JWT.

Most other JWT libraries set this header to "JWT", this explicitness is generally useful.