### PR TITLE
More compact JSON dumps for unicode strings

### DIFF
--- a/itsdangerous.py
+++ b/itsdangerous.py
@@ -48,7 +48,7 @@ class _CompactJSON(object):
         return json.loads(payload)
 
     def dumps(self, obj):
-        return json.dumps(obj, separators=(',', ':'))
+        return json.dumps(obj, ensure_ascii=False, separators=(',', ':'))
 
 
 compact_json = _CompactJSON()


### PR DESCRIPTION
Pass `ensure_ascii=False` to `json.dumps`, this will produce shorter json dumps.