### PR TITLE
enhance `TimedJSONWebSignatureSerializer` to support never-expire

### DIFF
--- a/itsdangerous.py
+++ b/itsdangerous.py
@@ -802,7 +802,7 @@ class TimedJSONWebSignatureSerializer(JSONWebSignatureSerializer):
             raise BadSignature('expiry date is not an IntDate',
                                payload=payload)
 
-        if header['exp'] < self.now():
+        if header['exp'] != header['iat'] and header['exp'] < self.now():
             raise SignatureExpired('Signature expired', payload=payload,
                                    date_signed=self.get_issue_date(header))
 

--- a/tests.py
+++ b/tests.py
@@ -252,6 +252,11 @@ class TimedJSONWebSignatureSerializerTest(unittest.TestCase):
         result = s.dumps({'foo': 'bar'})
         self.assertRaises(idmod.BadSignature, s.loads, result)
 
+    def test_token_is_valid_if_expiry_time_is_zero(self):
+        s = self.serializer_class('secret', expires_in=0)
+        result, header = s.loads(s.dumps({'foo': 'bar'}), return_header=True)
+        self.assertEqual(header['exp'] - header['iat'], 0)
+
     def test_creating_a_token_adds_the_expiry_date(self):
         expires_in_two_hours = 7200
         s = self.serializer_class('secret', expires_in=expires_in_two_hours)


### PR DESCRIPTION
Motivation
-------------

In `itsdangerous`, you can generate tokens without expiry time based on `JSONWebSignatureSerializer`:

    from itsdangerous import JSONWebSignatureSerializer as JWSSerializer

    def make_normal_token(secret_key, data):
        s = JWSSerializer(secret_key)
        return s.dumps(data)

and you can generate tokens with expiry time based on `TimedJSONWebSignatureSerializer`:

    from itsdangerous import TimedJSONWebSignatureSerializer as TimedJWSSerializer

    def make_timed_token(secret_key, data, expires=None):
        s = TimedJWSSerializer(secret_key, expires_in=expires)
        return s.dumps(data)

Then, you can merge the above two functions as one:

    from itsdangerous import JSONWebSignatureSerializer as JWSSerializer
    from itsdangerous import TimedJSONWebSignatureSerializer as TimedJWSSerializer

    def make_token(secret_key, data, expires=None):
        if expires == 0:
            s = JWSSerializer(secret_key)
        else:
            s = TimedJWSSerializer(secret_key, expires_in=expires)
        return s.dumps(data)

But there's no easy way (neither `JSONWebSignatureSerializer.loads()` nor `TimedJSONWebSignatureSerializer.loads()`) to load tokens generated by `make_token`. (Maybe any suggestions?)

    def load_token(secret_key, token):
        pass  # how to load?

Advantage
-------------

With the enhanced version of `TimedJSONWebSignatureSerializer`, everything above can be implemented as follows:

    from itsdangerous import TimedJSONWebSignatureSerializer as TimedJWSSerializer

    def make_token(secret_key, data, expires=None):
        s = TimedJWSSerializer(secret_key, expires_in=expires)
        return s.dumps(data)

    def load_data(secret_key, token):
        s = TimedJWSSerializer(secret_key)
        try:
            data = s.loads(token)
            return data
        except SignatureExpired:  # valid token, but expired
            return None
        except BadSignature:  # invalid token
            return None