### PR TITLE
Add PyPy 3 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - pypy3
 install:
   - pip install tox
 script:


### PR DESCRIPTION
'pypy3' on Travis passes all tests without modification.
Travis uses the following PyPy 3k version currently:

Python 3.2.5 (b2091e973da6, Oct 19 2014, 18:29:55)
[PyPy 2.4.0 with GCC 4.6.3]