### PR TITLE
Add license_file to setup.cfg metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,9 @@ release = egg_info -RDb ''
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [upload_docs]
 upload-dir = docs/_build/html
 


### PR DESCRIPTION
Without this, the LICENSE file is never included in the built wheels: this makes it harder for users to comply with the license.
With this addition a file LICENSE.txt will be created in the `xxx.dist-info` directory with the content of the `license_file` file, e.g. the top level LICENSE.
