### PR TITLE
Convert `exp` header to int if it is valid IntDate

### DIFF
--- a/itsdangerous.py
+++ b/itsdangerous.py
@@ -825,6 +825,11 @@ class TimedJSONWebSignatureSerializer(JSONWebSignatureSerializer):
         if 'exp' not in header:
             raise BadSignature('Missing expiry date', payload=payload)
 
+        try:
+            header['exp'] = int(header['exp'])
+        except ValueError:
+            raise BadHeader('Expiry date is not valid timestamp', payload=payload)
+
         if not (isinstance(header['exp'], number_types)
                 and header['exp'] > 0):
             raise BadSignature('expiry date is not an IntDate',


### PR DESCRIPTION
Some dynamic value generators of API tools (for example Paw https://paw.cloud/extensions/JsonWebTokenDynamicValue) generate string value for timestamp and it raises the bad signature error.