### PR TITLE
Add link to official Discord chat server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,3 +66,4 @@ Links
 *   Issue tracker: https://github.com/pallets/itsdangerous/issues
 *   Test status: https://travis-ci.org/pallets/itsdangerous
 *   Test coverage: https://codecov.io/gh/pallets/itsdangerous
+*   Official chat: https://discord.gg/t6rrQZH


### PR DESCRIPTION
All Pallets projects should have a link to the official chat server on Discord.