### PR TITLE
Raise SignatureExpired error when age is in the future 

### DIFF
--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -94,7 +94,7 @@ class TimestampSigner(Signer):
                     date_signed=self.timestamp_to_datetime(timestamp),
                 )
             if age < 0:
-                raise BadTimeSignature(
+                raise SignatureExpired(
                     "Signature age %s < 0 seconds" % (age),
                     payload=value,
                     date_signed=self.timestamp_to_datetime(timestamp),

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -93,6 +93,12 @@ class TimestampSigner(Signer):
                     payload=value,
                     date_signed=self.timestamp_to_datetime(timestamp),
                 )
+            if age < 0:
+                raise BadTimeSignature(
+                    "Signature age %s < 0 seconds" % (age),
+                    payload=value,
+                    date_signed=self.timestamp_to_datetime(timestamp),
+                )
 
         if return_timestamp:
             return value, self.timestamp_to_datetime(timestamp)

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -70,6 +70,7 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
             with pytest.raises(SignatureExpired):
                 signer.unsign(signed, max_age=10)
 
+
 class TestTimedSerializer(FreezeMixin, TestSerializer):
     @pytest.fixture()
     def serializer_factory(self):

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -65,7 +65,7 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
 
     def test_future_age(self, signer):
         signed = signer.sign("value")
-        
+
         with freeze_time("1971-05-31"):
             with pytest.raises(SignatureExpired):
                 signer.unsign(signed, max_age=10)

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -63,6 +63,12 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
 
         assert "Malformed" in str(exc_info.value)
 
+    def test_future_age(self, signer):
+        signed = signer.sign("value")
+        
+        with freeze_time("1971-05-31"):
+            with pytest.raises(SignatureExpired) as exc_info:
+                signer.unsign(signed, max_age=10)
 
 class TestTimedSerializer(FreezeMixin, TestSerializer):
     @pytest.fixture()

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -67,7 +67,7 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
         signed = signer.sign("value")
         
         with freeze_time("1971-05-31"):
-            with pytest.raises(SignatureExpired) as exc_info:
+            with pytest.raises(SignatureExpired):
                 signer.unsign(signed, max_age=10)
 
 class TestTimedSerializer(FreezeMixin, TestSerializer):


### PR DESCRIPTION
This is a fix for the issue reported in [issue#126](https://github.com/pallets/itsdangerous/issues/126). This conditional checks that the age is not a future date.