### PR TITLE
Key rotate

### DIFF
--- a/src/itsdangerous/jws.py
+++ b/src/itsdangerous/jws.py
@@ -57,7 +57,7 @@ class JSONWebSignatureSerializer(Serializer):
             stacklevel=2,
         )
         super().__init__(
-            secret_key=secret_key,
+            secret_key,
             salt=salt,
             serializer=serializer,
             serializer_kwargs=serializer_kwargs,
@@ -138,7 +138,7 @@ class JSONWebSignatureSerializer(Serializer):
             algorithm = self.algorithm
 
         return self.signer(
-            self.secret_key,
+            self.secret_keys,
             salt=salt,
             sep=".",
             key_derivation=key_derivation,

--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -83,10 +83,16 @@ class Serializer:
         fallback_signers=None,
     ):
         if isinstance(secret_key, list):
-            self.secret_keys = [want_bytes(s) for s in secret_key]
+            secret_keys = [want_bytes(s) for s in secret_key]
         else:
-            self.secret_keys = [want_bytes(secret_key)]
+            secret_keys = [want_bytes(secret_key)]
 
+        #: The list of secret keys to try for verifying signatures, from
+        #: oldest to newest. The newest (last) key is used for signing.
+        #:
+        #: This allows a key rotation system to keep a list of allowed
+        #: keys and remove expired ones.
+        self.secret_keys = secret_keys
         self.salt = want_bytes(salt)
 
         if serializer is None:
@@ -106,6 +112,13 @@ class Serializer:
 
         self.fallback_signers = fallback_signers
         self.serializer_kwargs = serializer_kwargs or {}
+
+    @property
+    def secret_key(self):
+        """The newest (last) entry in the :attr:`secret_keys` list. This
+        is for compatibility from before key rotation support was added.
+        """
+        return self.secret_keys[-1]
 
     def load_payload(self, payload, serializer=None):
         """Loads the encoded object. This function raises

--- a/tests/test_itsdangerous/test_jws.py
+++ b/tests/test_itsdangerous/test_jws.py
@@ -67,6 +67,17 @@ class TestJWSSerializer(TestSerializer):
 
         assert match in str(exc_info.value)
 
+    def test_secret_keys(self):
+        with pytest.deprecated_call():
+            serializer = JSONWebSignatureSerializer("a")
+
+        dumped = serializer.dumps("value")
+
+        with pytest.deprecated_call():
+            serializer = JSONWebSignatureSerializer(["a", "b"])
+
+        assert serializer.loads(dumped) == "value"
+
 
 class TestTimedJWSSerializer(TestJWSSerializer, TestTimedSerializer):
     @pytest.fixture()

--- a/tests/test_itsdangerous/test_signer.py
+++ b/tests/test_itsdangerous/test_signer.py
@@ -91,6 +91,16 @@ class TestSigner:
         if algorithm is None:
             assert signer.algorithm.digest_method == signer.digest_method
 
+    def test_secret_keys(self):
+        signer = Signer("a")
+        signed = signer.sign("my string")
+        assert isinstance(signed, bytes)
+
+        signer = Signer(["a", "b"])
+        assert signer.validate(signed)
+        out = signer.unsign(signed)
+        assert out == b"my string"
+
 
 def test_abstract_algorithm():
     alg = SigningAlgorithm()


### PR DESCRIPTION
This change is designed for https://github.com/pallets/flask/issues/1574

With this change, `Signer` and `Serializer` can accept a list of secret keys. For instance,

1. In 2019/09, we are using `a` as the secret key
2. In 2019/10, we are going to use `b` as the secret key

For 2019/09, we will use `Serializer(['a'])`, and later in 10, we will use `Serializer(['a', 'b'])`. Now the old dumped values can still be loaded, because `a` is in secret keys. But it will dump new value with secret key `b` in 2019/10.

Later, we can remove `a` from the secret keys, since it is not used anymore. Maybe in 2019/11.