### PR TITLE
jws.py: support return_header in dumps()

### DIFF
--- a/src/itsdangerous/jws.py
+++ b/src/itsdangerous/jws.py
@@ -126,14 +126,18 @@ class JSONWebSignatureSerializer(Serializer):
         header["alg"] = self.algorithm_name
         return header
 
-    def dumps(self, obj, salt=None, header_fields=None):
+    def dumps(self, obj, salt=None, header_fields=None, return_header=False):
         """Like :meth:`.Serializer.dumps` but creates a JSON Web
         Signature. It also allows for specifying additional fields to be
         included in the JWS header.
         """
         header = self.make_header(header_fields)
         signer = self.make_signer(salt, self.algorithm)
-        return signer.sign(self.dump_payload(header, obj))
+        signed = signer.sign(self.dump_payload(header, obj))
+        if return_header:
+            return signed, header
+        else:
+            return signed
 
     def loads(self, s, salt=None, return_header=False):
         """Reverse of :meth:`dumps`. If requested via ``return_header``

--- a/tests/test_itsdangerous/test_jws.py
+++ b/tests/test_itsdangerous/test_jws.py
@@ -98,6 +98,11 @@ class TestTimedJWSSerializer(TestJWSSerializer, TestTimedSerializer):
         date_signed = serializer.get_issue_date(header)
         assert (payload, date_signed) == (value, ts)
 
+    def test_dumps_return_header(self, serializer, value, ts):
+        signed, dumped_header = serializer.dumps(value, return_header=True)
+        payload, loaded_header = serializer.loads(signed, return_header=True)
+        assert dumped_header == loaded_header
+
     def test_missing_exp(self, serializer):
         header = serializer.make_header(None)
         del header["exp"]


### PR DESCRIPTION
Useful for retrieving the headers generated in make_headers such as `alg`, `exp` and `iat`.