### PR TITLE
Changes TimestampSigner to sign with UTC timestamp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Version 2.0.0
 Unreleased
 
 -   Drop support for Python 2 and 3.5.
+-   Signature timestamps are in UTC rather than local time. This may
+    cause some tokens to expire a few hours early or late if the server
+    is not set to UTC. :issue:`137`
 
 
 Version 1.1.0

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -1,5 +1,5 @@
-import time
 from datetime import datetime
+from datetime import timezone
 
 from .encoding import base64_decode
 from .encoding import base64_encode
@@ -21,10 +21,10 @@ class TimestampSigner(Signer):
     """
 
     def get_timestamp(self):
-        """Returns the current timestamp. The function must return an
-        integer.
+        """Returns the current UTC timestamp. The function must return
+        an integer.
         """
-        return int(time.time())
+        return int(datetime.now(tz=timezone.utc).timestamp())
 
     def timestamp_to_datetime(self, ts):
         """Used to convert the timestamp from :meth:`get_timestamp` into


### PR DESCRIPTION
- References #137
- Get UTC timestamp according to Python's documentation
(https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow)