### PR TITLE
remove simplejson and deprecate itsdangerous.json

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Version 2.0.0
 Unreleased
 
 -   Drop support for Python 2 and 3.5.
+-   Importing ``itsdangerous.json`` is deprecated. Import Python's
+    ``json`` module instead. :pr:`152`
+-   Simplejson is no longer used if it is installed. To use a different
+    library, pass it as ``Serializer(serializer=...)``. :issue:`146`
 -   ``datetime`` values are timezone-aware with ``timezone.utc``. Code
     using ``TimestampSigner.unsign(return_timestamp=True)`` or
     ``BadTimeSignature.date_signed`` may need to change. :issue:`150`

--- a/docs/serializer.rst
+++ b/docs/serializer.rst
@@ -25,9 +25,8 @@ the data.
     s.loads('[1, 2, 3, 4].r7R9RhGgDPvvWl3iNzLuIIfELmo')
     [1, 2, 3, 4]
 
-By default, data is serialized to JSON. If simplejson is installed, it
-is preferred over the built-in :mod:`json` module. This internal
-serializer can be changed by subclassing.
+By default, data is serialized to JSON with the built-in :mod:`json`
+module. This internal serializer can be changed by subclassing.
 
 To record and validate the age of the signature, see :doc:`/timed`.
 To serialize to a format that is safe to use in URLs, see

--- a/src/itsdangerous/__init__.py
+++ b/src/itsdangerous/__init__.py
@@ -1,4 +1,4 @@
-from ._json import json
+from ._json import deprecated_json as json
 from .encoding import base64_decode
 from .encoding import base64_encode
 from .encoding import want_bytes

--- a/src/itsdangerous/_json.py
+++ b/src/itsdangerous/_json.py
@@ -1,7 +1,5 @@
-try:
-    import simplejson as json
-except ImportError:
-    import json
+import json
+from types import ModuleType
 
 
 class _CompactJSON:
@@ -16,3 +14,19 @@ class _CompactJSON:
         kwargs.setdefault("ensure_ascii", False)
         kwargs.setdefault("separators", (",", ":"))
         return json.dumps(obj, **kwargs)
+
+
+class DeprecatedJSON(ModuleType):
+    def __getattribute__(self, item):
+        import warnings
+
+        warnings.warn(
+            "Importing 'itsdangerous.json' is deprecated and will be"
+            " removed in 2.1. Use Python's 'json' module instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return getattr(json, item)
+
+
+deprecated_json = DeprecatedJSON("json")

--- a/src/itsdangerous/jws.py
+++ b/src/itsdangerous/jws.py
@@ -6,7 +6,6 @@ from decimal import Decimal
 from numbers import Real
 
 from ._json import _CompactJSON
-from ._json import json
 from .encoding import base64_decode
 from .encoding import base64_encode
 from .encoding import want_bytes
@@ -87,7 +86,7 @@ class JSONWebSignatureSerializer(Serializer):
             )
 
         try:
-            header = super().load_payload(json_header, serializer=json)
+            header = super().load_payload(json_header, serializer=_CompactJSON)
         except BadData as e:
             raise BadHeader(
                 "Could not unserialize header because it was malformed",

--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -1,6 +1,6 @@
 import hashlib
+import json
 
-from ._json import json
 from .encoding import want_bytes
 from .exc import BadPayload
 from .exc import BadSignature
@@ -19,10 +19,6 @@ class Serializer:
     underlying implementation for parsing and loading you have to
     override the :meth:`load_payload` and :meth:`dump_payload`
     functions.
-
-    This implementation uses simplejson if available for dumping and
-    loading and will fall back to the standard library's json module if
-    it's not available.
 
     You do not need to subclass this class in order to switch out or
     customize the :class:`.Signer`. You can instead pass a different


### PR DESCRIPTION
Removes simplejson in favor of Python's built-in json module. Since `itsdangerous.json` would just be an alias for that module now, it's replaced with an proxy that raises a deprecation warning on use.

closes #146 