### PR TITLE
date_signed is datetime not int

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Unreleased
 -   If a signature has an age less than 0, it will raise
     ``SignatureExpired`` rather than appearing valid. This can happen if
     the timestamp offset is changed. :issue:`126`
+-   ``BadTimeSignature.date_signed`` is always a ``datetime`` object
+    rather than an ``int`` in some cases. :issue:`124`
 
 
 Version 1.1.0

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -86,6 +86,9 @@ class TimestampSigner(Signer):
         # Signature is *not* okay. Raise a proper error now that we have
         # split the value and the timestamp.
         if sig_error is not None:
+            if timestamp is not None:
+                timestamp = self.timestamp_to_datetime(timestamp)
+
             raise BadTimeSignature(str(sig_error), payload=value, date_signed=timestamp)
 
         # Signature was okay but the timestamp is actually not there or


### PR DESCRIPTION
For timed serializers, a bad signature could result in `date_signed` being the raw int timestamp instead of a datetime. It is now consistently a datetime.

closes #124 