### PR TITLE
create a new doc for general concepts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Unreleased
     the timestamp offset is changed. :issue:`126`
 -   ``BadTimeSignature.date_signed`` is always a ``datetime`` object
     rather than an ``int`` in some cases. :issue:`124`
+-   Added support for key rotation. A list of keys can be passed as
+    ``secret_key``, oldest to newest. The newest key is used for
+    signing, all keys are tried for unsigning. :pr:`141`
 
 
 Version 1.1.0

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,0 +1,154 @@
+General Concepts
+================
+
+
+Serializer vs Signer
+--------------------
+
+ItsDangerous provides two levels of data handling. The :doc:`/signer` is
+the basic system that signs a given ``bytes`` value based on the given
+signing parameters. The :doc:`/serializer` wraps a signer to enable
+serializing and signing other data besides ``bytes``.
+
+Typically, you'll want to use a serializer, not a signer. You can
+configure the signing parameters through the serializer, and even
+provide fallback signers to upgrade old tokens to new parameters.
+
+
+The Secret Key
+--------------
+
+Signatures are secured by the ``secret_key``. Typically one secret key
+is used with all signers, and the salt is used to distinguish different
+contexts. Changing the secret key will invalidate existing tokens.
+
+It should be a long random string of bytes. This value must be kept
+secret and should not be saved in source code or committed to version
+control. If an attacker learns the secret key, they can change and
+resign data to look valid. If you suspect this happened, change the
+secret key to invalidate existing tokens.
+
+One way to keep the secret key separate is to read it from an
+environment variable. When deploying for the first time, generate a key
+and set the environment variable when running the application. All
+process managers (like systemd) and hosting services have a way to
+specify environment variables.
+
+.. code-block:: python
+
+    import os
+    from itsdangerous.serializer import Serializer
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+    s = Serializer(SECRET_KEY)
+
+.. code-block:: text
+
+    $ export SECRET_KEY="base64 encoded random bytes"
+    $ python application.py
+
+One way to generate a key is to use :func:`os.urandom`.
+
+.. code-block:: text
+
+    $ python3 -c 'import os; print(os.urandom(16).hex())'
+
+
+The Salt
+--------
+
+The salt is combined with the secret key to derive a unique key for
+distinguishing different contexts. Unlike the secret key, the salt
+doesn't have to be random, and can be saved in code. It only has to be
+unique between contexts, not private.
+
+For example, you want to email activation links to activate user
+accounts, and upgrade links to upgrade users to a paid accounts. If all
+you sign is the user id, and you don't use different salts, a user could
+reuse the token from the activation link to upgrade the account. If you
+use different salts, the signatures will be different and will not be
+valid in the other context.
+
+.. code-block:: python
+
+    from itsdangerous.url_safe import URLSafeSerializer
+
+    s1 = URLSafeSerializer("secret-key", salt="activate")
+    s1.dumps(42)
+    'NDI.MHQqszw6Wc81wOBQszCrEE_RlzY'
+
+    s2 = URLSafeSerializer("secret-key", salt="upgrade")
+    s2.dumps(42)
+    'NDI.c0MpsD6gzpilOAeUPra3NShPXsE'
+
+The second serializer can't load data dumped with the first because the
+salts differ.
+
+.. code-block:: python
+
+    s2.loads(s1.dumps(42))
+    Traceback (most recent call last):
+      ...
+    BadSignature: Signature does not match
+
+Only the serializer with the same salt can load the data.
+
+.. code-block:: python
+
+    s2.loads(s2.dumps(42))
+    42
+
+
+Key Rotation
+------------
+
+Key rotation can provide an extra layer of mitigation against an
+attacker discovering a secret key. A rotation system will keep a list of
+valid keys, generating a new key and removing the oldest key
+periodically. If it takes four weeks for an attacker to crack a key, but
+the key is rotated out after three weeks, they will not be able to use
+any keys they crack. However, if a user doesn't refresh their token
+within three weeks it will be invalid too.
+
+The system that generates and maintains this list is outside the scope
+of ItsDangerous, but ItsDangerous does support validating against a list
+of keys.
+
+Instead of passing a single key, you can pass a list of keys, oldest to
+newest. When signing the last (newest) key will be used, and when
+validating each key will be tried from newest to oldest before raising
+a validation error.
+
+.. code-block:: python
+
+    SECRET_KEYS = ["2b9cd98e", "169d7886", "b6af09f5"]
+
+    # sign some data with the latest key
+    s = Serializer(SECRET_KEYS)
+    t = s.dumps({"id": 42})
+
+    # rotate a new key in and the oldest key out
+    SECRET_KEYS.append("cf9b3588")
+    del SECRET_KEYS[0]
+
+    s = Serializer(SECRET_KEYS)
+    s.loads(t)  # valid even though it was signed with a previous key
+
+
+Digest Method Security
+----------------------
+
+A signer is configured with a ``digest_method``, a hash function that
+is used as an intermediate step when generating the HMAC signature. The
+default method is :func:`hashlib.sha1`. Occasionally, users are
+concerned about this default because they have heard about hash
+collisions with SHA-1.
+
+When used as the intermediate, iterated step in HMAC, SHA-1 is not
+insecure. In fact, even MD5 is still secure in HMAC. The security of the
+hash alone doesn't apply when used in HMAC.
+
+If a project considers SHA-1 a risk anyway, they can configure the
+signer with a different digest method such as :func:`hashlib.sha512`.
+A fallback signer for SHA-1 can be configured so that old tokens will be
+upgraded. SHA-512 produces a longer hash, so tokens will take up more
+space, which is relevant in cookies and URLs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,20 +7,17 @@ ItsDangerous
     :align: center
     :target: https://palletsprojects.com/p/itsdangerous/
 
-Sometimes you just want to send some data to untrusted environments. But
-how to do this safely? The trick involves signing. Given a key only you
-know, you can cryptographically sign your data and hand it over to
-someone else. When you get the data back you can easily ensure that
-nobody tampered with it.
+Sometimes you want to send some data to untrusted environments, then get
+it back later. To do this safely, the data must be signed to detect
+changes.
 
-Granted, the receiver can decode the contents and look into the package,
-but they can not modify the contents unless they also have your secret
-key. So if you keep the key secret and complex, you will be fine.
+Given a key only you know, you can cryptographically sign your data and
+hand it over to someone else. When you get the data back you can ensure
+that nobody tampered with it.
 
-Internally ItsDangerous uses HMAC and SHA-512 for signing by default.
-The initial implementation was inspired by `Django's signing module
-<https://docs.djangoproject.com/en/dev/topics/signing/>`_. It also
-supports JSON Web Signatures (JWS). The library is BSD licensed.
+The receiver can see the data, but they can not modify it unless they
+also have your key. So if you keep the key secret and complex, you will
+be fine.
 
 
 Installing
@@ -38,10 +35,10 @@ Install and update using `pip`_:
 Example Use Cases
 -----------------
 
--   You can serialize and sign a user ID in a URL and email it to them
-    to unsubscribe from a newsletter. This way you don't need to
-    generate one-time tokens and store them in the database. Same thing
-    with any kind of activation link for accounts and similar things.
+-   Sign a user ID in a URL and email it to them to unsubscribe from a
+    newsletter. This way you don't need to generate one-time tokens and
+    store them in the database. Same thing with any kind of activation
+    link for accounts and similar things.
 -   Signed objects can be stored in cookies or other untrusted sources
     which means you don't need to have sessions stored on the server,
     which reduces the number of necessary database queries.
@@ -55,8 +52,9 @@ Table of Contents
 
 .. toctree::
 
-    signer
+    concepts
     serializer
+    signer
     exceptions
     timed
     url_safe

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,4 +1,4 @@
-License
-=======
+BSD-3-Clause License
+====================
 
 .. include:: ../LICENSE.rst

--- a/docs/signer.rst
+++ b/docs/signer.rst
@@ -33,7 +33,7 @@ unsigning will raise a :exc:`~itsdangerous.exc.BadSignature` exception:
     s.unsign(b"different string.wh6tMHxLgJqB6oY1uT73iMlyrOA")
     Traceback (most recent call last):
       ...
-    itsdangerous.exc.BadSignature: Signature "wh6tMHxLgJqB6oY1uT73iMlyrOA" does not match
+    BadSignature: Signature does not match
 
 To record and validate the age of a signature, see :doc:`/timed`.
 

--- a/docs/timed.rst
+++ b/docs/timed.rst
@@ -4,9 +4,9 @@ Signing With Timestamps
 =======================
 
 If you want to expire signatures you can use the
-:class:`TimestampSigner` class which will adds timestamp information and
-signs it. On unsigning you can validate that the timestamp did not
-expire:
+:class:`TimestampSigner` class which adds timestamp information and
+signs it. On unsigning you can validate that the timestamp is not older
+than a given age.
 
 .. code-block:: python
 

--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -13,63 +13,63 @@ def is_text_serializer(serializer):
 
 
 class Serializer:
-    """This class provides a serialization interface on top of the
-    signer. It provides a similar API to json/pickle and other modules
-    but is structured differently internally. If you want to change the
-    underlying implementation for parsing and loading you have to
-    override the :meth:`load_payload` and :meth:`dump_payload`
-    functions.
+    """A serializer wraps a :class:`~itsdangerous.signer.Signer` to
+    enable serializing and securely signing data other than bytes. It
+    can unsign to verify that the data hasn't been changed.
 
-    You do not need to subclass this class in order to switch out or
-    customize the :class:`.Signer`. You can instead pass a different
-    class to the constructor as well as keyword arguments as a dict that
-    should be forwarded.
+    The serializer provides :meth:`dumps` and :meth:`loads`, similar to
+    :mod:`json`, and by default uses :mod:`json` internally to serialize
+    the data to bytes.
 
-    .. code-block:: python
+    The secret key should be a random string of ``bytes`` and should not
+    be saved to code or version control. Different salts should be used
+    to distinguish signing in different contexts. See :doc:`/concepts`
+    for information about the security of the secret key and salt.
 
-        s = Serializer(signer_kwargs={'key_derivation': 'hmac'})
+    :param secret_key: The secret key to sign and verify with. Can be a
+        list of keys, oldest to newest, to support key rotation.
+    :param salt: Extra key to combine with ``secret_key`` to distinguish
+        signatures in different contexts.
+    :param serializer: An object that provides ``dumps`` and ``loads``
+        methods for serializing data to a string. Defaults to
+        :attr:`default_serializer`, which defaults to :mod:`json`.
+    :param serializer_kwargs: Keyword arguments to pass when calling
+        ``serializer.dumps``.
+    :param signer: A ``Signer`` class to instantiate when signing data.
+        Defaults to :attr:`default_signer`, which defaults to
+        :class:`~itsdangerous.signer.Signer`.
+    :param signer_kwargs: Keyword arguments to pass when instantiating
+        the ``Signer`` class.
+    :param fallback_signers: List of signer parameters to try when
+        unsigning with the default signer fails. Each item can be a dict
+        of ``signer_kwargs``, a ``Signer`` class, or a tuple of
+        ``(signer, signer_kwargs)``. Defaults to
+        :attr:`default_fallback_signers`.
 
-    You may want to upgrade the signing parameters without invalidating
-    existing signatures that are in use. Fallback signatures can be
-    given that will be tried if unsigning with the current signer fails.
+    .. versionchanged:: 2.0.0
+        Added support for key rotation by passing a list to
+        ``secret_key``.
 
-    Fallback signers can be defined by providing a list of
-    ``fallback_signers``. Each item can be one of the following: a
-    signer class (which is instantiated with ``signer_kwargs``,
-    ``salt``, and ``secret_key``), a tuple
-    ``(signer_class, signer_kwargs)``, or a dict of ``signer_kwargs``.
-
-    For example, this is a serializer that signs using SHA-512, but will
-    unsign using either SHA-512 or SHA1:
-
-    .. code-block:: python
-
-        s = Serializer(
-            signer_kwargs={"digest_method": hashlib.sha512},
-            fallback_signers=[{"digest_method": hashlib.sha1}]
-        )
-
-    .. versionchanged:: 0.14:
-        The ``signer`` and ``signer_kwargs`` parameters were added to
-        the constructor.
-
-    .. versionchanged:: 1.1.0:
+    .. versionchanged:: 1.1.0
         Added support for ``fallback_signers`` and configured a default
         SHA-512 fallback. This fallback is for users who used the yanked
         1.0.0 release which defaulted to SHA-512.
+
+    .. versionchanged:: 0.14
+        The ``signer`` and ``signer_kwargs`` parameters were added to
+        the constructor.
     """
 
-    #: If a serializer module or class is not passed to the constructor
-    #: this one is picked up. This currently defaults to :mod:`json`.
+    #: The default serialization module to use to serialize data to a
+    #: string internally. The default is :mod:`json`, but can be changed
+    #: to any object that provides ``dumps`` and ``loads`` methods.
     default_serializer = json
 
-    #: The default :class:`Signer` class that is being used by this
-    #: serializer.
-    #:
-    #: .. versionadded:: 0.14
+    #: The default ``Signer`` class to instantiate when signing data.
+    #: The default is :class:`itsdangerous.signer.Signer`.
     default_signer = Signer
 
-    #: The default fallback signers.
+    #: The default fallback signers to try when unsigning fails.
     default_fallback_signers = [{"digest_method": hashlib.sha512}]
 
     def __init__(

--- a/src/itsdangerous/signer.py
+++ b/src/itsdangerous/signer.py
@@ -53,37 +53,54 @@ class HMACAlgorithm(SigningAlgorithm):
 
 
 class Signer:
-    """This class can sign and unsign bytes, validating the signature
-    provided.
+    """A signer securely signs bytes, then unsigns them to verify that
+    the value hasn't been changed.
 
-    Salt can be used to namespace the hash, so that a signed string is
-    only valid for a given namespace. Leaving this at the default value
-    or re-using a salt value across different parts of your application
-    where the same signed value in one part can mean something different
-    in another part is a security risk.
+    The secret key should be a random string of ``bytes`` and should not
+    be saved to code or version control. Different salts should be used
+    to distinguish signing in different contexts. See :doc:`/concepts`
+    for information about the security of the secret key and salt.
 
-    See :ref:`the-salt` for an example of what the salt is doing and how
-    you can utilize it.
+    :param secret_key: The secret key to sign and verify with. Can be a
+        list of keys, oldest to newest, to support key rotation.
+    :param salt: Extra key to combine with ``secret_key`` to distinguish
+        signatures in different contexts.
+    :param sep: Separator between the signature and value.
+    :param key_derivation: How to derive the signing key from the secret
+        key and salt. Possible values are ``concat``, ``django-concat``,
+        or ``hmac``. Defaults to :attr:`default_key_derivation`, which
+        defaults to ``django-concat``.
+    :param digest_method: Hash function to use when generating the HMAC
+        signature. Defaults to :attr:`default_digest_method`, which
+        defaults to :func:`hashlib.sha1`. Note that the security of the
+        hash alone doesn't apply when used intermediately in HMAC.
+    :param algorithm: A :class:`SigningAlgorithm` instance to use
+        instead of building a default :class:`HMACAlgorithm` with the
+        ``digest_method``.
 
-    .. versionadded:: 0.14
+    .. versionchanged:: 2.0
+        Added support for key rotation by passing a list to
+        ``secret_key``.
+
+    .. versionchanged:: 0.18
+        ``algorithm`` was added as an argument to the class constructor.
+
+    .. versionchanged:: 0.14
         ``key_derivation`` and ``digest_method`` were added as arguments
         to the class constructor.
-
-    .. versionadded:: 0.18
-        ``algorithm`` was added as an argument to the class constructor.
     """
 
-    #: The digest method to use for the signer.  This defaults to
-    #: SHA1 but can be changed to any other function in the hashlib
-    #: module.
+    #: The default digest method to use for the signer. The default is
+    #: :func:`hashlib.sha1`, but can be changed to any :mod:`hashlib` or
+    #: compatible object. Note that the security of the hash alone
+    #: doesn't apply when used intermediately in HMAC.
     #:
     #: .. versionadded:: 0.14
     default_digest_method = staticmethod(hashlib.sha1)
 
-    #: Controls how the key is derived. The default is Django-style
-    #: concatenation. Possible values are ``concat``, ``django-concat``
-    #: and ``hmac``. This is used for deriving a key from the secret key
-    #: with an added salt.
+    #: The default scheme to use to derive the signing key from the
+    #: secret key and salt. The default is ``django-concat``. Possible
+    #: values are ``concat``, ``django-concat``, and ``hmac``.
     #:
     #: .. versionadded:: 0.14
     default_key_derivation = "django-concat"
@@ -113,8 +130,8 @@ class Signer:
         if self.sep in _base64_alphabet:
             raise ValueError(
                 "The given separator cannot be used because it may be"
-                " contained in the signature itself. Alphanumeric"
-                " characters and `-_=` must not be used."
+                " contained in the signature itself. ASCII letters,"
+                " digits, and '-_=' must not be used."
             )
 
         self.salt = "itsdangerous.Signer" if salt is None else salt
@@ -147,6 +164,12 @@ class Signer:
         intended to be used as a security method to make a complex key
         out of a short password. Instead you should use large random
         secret keys.
+
+        :param secret_key: A specific secret key to derive from.
+            Defaults to the last item in :attr:`secret_keys`.
+
+        .. versionchanged:: 2.0
+            Added the ``secret_key`` parameter.
         """
         if secret_key is None:
             secret_key = self.secret_keys[-1]


### PR DESCRIPTION
Originally was only writing docs for key rotation (#141), but noticed there wasn't really a discussion on the general security concepts of the secret key, salt, etc.

This adds a new concepts page that discusses the secret key, salt, key rotation, and digest method, rather than having coverage spread out between signer and serializer pages and docstrings. Moves the docs on fallback signers to the serializer page instead of taking up half the docstring. Adds documentation for each signer and serializer parameter.

Also hit some other docs cleanup