### PR TITLE
add typing with mypy

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,6 +21,7 @@ jobs:
           - {name: '3.6', python: '3.6', os: ubuntu-latest, tox: py36}
           - {name: 'PyPy', python: pypy3, os: ubuntu-latest, tox: pypy3}
           - {name: Style, python: '3.8', os: ubuntu-latest, tox: style}
+          - {name: Typing, python: '3.8', os: ubuntu-latest, tox: typing}
           - {name: Docs, python: '3.8', os: ubuntu-latest, tox: docs}
           - {name: Windows, python: '3.8', os: windows-latest, tox: py38}
           - {name: Mac, python: '3.8', os: macos-latest, tox: py38}
@@ -34,19 +35,27 @@ jobs:
           pip install -U wheel
           pip install -U setuptools
           python -m pip install -U pip
-      - name: get pip cache dir
-        id: pip-cache
-        run: echo "::set-output name=dir::$(pip cache dir)"
+      - name: set cache vars
+        id: vars
+        run: |
+          echo "::set-output name=pip::$(pip cache dir)"
+          echo "::set-output name=py::$(python -VV | sha256sum | cut -d' ' -f1)"
       - name: cache pip
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
-          path: ${{ steps.pip-cache.outputs.dir }}
-          key: pip|${{ runner.os }}|${{ matrix.python }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
+          path: ${{ steps.vars.outputs.pip }}
+          key: pip|${{ runner.os }}|${{ steps.vars.outputs.py }}|${{ hashFiles('setup.py') }}|${{ hashFiles('requirements/*.txt') }}
       - name: cache pre-commit
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/pre-commit
-          key: pre-commit|${{ matrix.python }}|${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit|${{ steps.vars.outputs.py }}|${{ hashFiles('.pre-commit-config.yaml') }}
         if: matrix.tox == 'style'
+      - name: cache mypy
+        uses: actions/cache@v2
+        with:
+          path: ./.mypy_cache
+          key: mypy|${{ steps.vars.outputs.py }}|${{ hashFiles('setup.cfg') }}
+        if: matrix.tox == 'typing'
       - run: pip install tox
       - run: tox -e ${{ matrix.tox }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 .coverage.*
 /htmlcov/
 /docs/_build/
+/.mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,27 +1,27 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.4.3
+    rev: v2.7.2
     hooks:
       - id: pyupgrade
         args: ["--py36-plus"]
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v2.3.0
+    rev: v2.3.5
     hooks:
       - id: reorder-python-imports
         args: ["--application-directories", "src:tests"]
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.3
     hooks:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear
           - flake8-implicit-str-concat
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.0.1
+    rev: v3.2.0
     hooks:
       - id: check-byte-order-marker
       - id: trailing-whitespace

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Unreleased
     signing, all keys are tried for unsigning. :pr:`141`
 -   Removed the default SHA-512 fallback signer from
     ``default_fallback_signers``. :issue:`155`
+-   Add type information for static typing tools. :pr:`186`
 
 
 Version 1.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include requirements/*.txt
 graft docs
 prune docs/_build
 graft tests
+include src/itsdangerous/py.typed
 global-exclude *.pyc

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,8 @@ extensions = [
     "sphinxcontrib.log_cabinet",
     "sphinx_issues",
 ]
+autoclass_content = "both"
+autodoc_typehints = "description"
 intersphinx_mapping = {"python": ("https://docs.python.org/3/", None)}
 issues_github_path = "pallets/itsdangerous"
 

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,6 @@
 -r docs.in
 -r tests.in
+mypy
+pip-tools
 pre-commit
 tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,6 +11,7 @@ babel==2.8.0              # via sphinx
 certifi==2020.4.5.1       # via requests
 cfgv==3.1.0               # via pre-commit
 chardet==3.0.4            # via requests
+click==7.1.2              # via pip-tools
 distlib==0.3.0            # via virtualenv
 docutils==0.16            # via sphinx
 filelock==3.0.12          # via tox, virtualenv
@@ -22,9 +23,12 @@ iniconfig==1.0.0          # via pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.3.0     # via pytest
+mypy-extensions==0.4.3    # via mypy
+mypy==0.782               # via -r requirements/dev.in
 nodeenv==1.3.5            # via pre-commit
 packaging==20.3           # via pallets-sphinx-themes, pytest, sphinx, tox
 pallets-sphinx-themes==1.2.3  # via -r requirements/docs.in
+pip-tools==5.3.1          # via -r requirements/dev.in
 pluggy==0.13.1            # via pytest, tox
 pre-commit==2.7.1         # via -r requirements/dev.in
 py==1.9.0                 # via pytest, tox
@@ -35,7 +39,7 @@ python-dateutil==2.8.1    # via freezegun
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via pre-commit
 requests==2.23.0          # via sphinx
-six==1.14.0               # via freezegun, packaging, python-dateutil, tox, virtualenv
+six==1.14.0               # via freezegun, packaging, pip-tools, python-dateutil, tox, virtualenv
 snowballstemmer==2.0.0    # via sphinx
 sphinx-issues==1.2.0      # via -r requirements/docs.in
 sphinx==3.2.1             # via -r requirements/docs.in, pallets-sphinx-themes, sphinx-issues, sphinxcontrib-log-cabinet
@@ -48,8 +52,11 @@ sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 toml==0.10.1              # via pre-commit, pytest, tox
 tox==3.19.0               # via -r requirements/dev.in
+typed-ast==1.4.1          # via mypy
+typing-extensions==3.7.4.3  # via mypy
 urllib3==1.25.9           # via requests
 virtualenv==20.0.20       # via pre-commit, tox
 
 # The following packages are considered to be unsafe in a requirements file:
+# pip
 # setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,3 +69,30 @@ max-line-length = 80
 per-file-ignores =
     # __init__ export names
     src/itsdangerous/__init__.py: F401
+
+[mypy]
+files = src/itsdangerous/, tests/
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true
+warn_unreachable = true
+local_partial_types = true
+no_implicit_reexport = true
+strict_equality = true
+
+[mypy-itsdangerous.jws]
+disallow_untyped_defs = false
+
+[mypy-test_itsdangerous.*]
+disallow_untyped_defs = false
+check_untyped_defs = true
+
+[mypy-test_itsdangerous.test_jws]
+check_untyped_defs = false
+
+[mypy-freezegun.*]
+ignore_missing_imports = true

--- a/src/itsdangerous/_json.py
+++ b/src/itsdangerous/_json.py
@@ -1,4 +1,5 @@
 import json
+import typing as _t
 from types import ModuleType
 
 
@@ -6,18 +7,18 @@ class _CompactJSON:
     """Wrapper around json module that strips whitespace."""
 
     @staticmethod
-    def loads(payload):
+    def loads(payload: _t.Union[str, bytes]) -> _t.Any:
         return json.loads(payload)
 
     @staticmethod
-    def dumps(obj, **kwargs):
+    def dumps(obj: _t.Any, **kwargs: _t.Any) -> str:
         kwargs.setdefault("ensure_ascii", False)
         kwargs.setdefault("separators", (",", ":"))
         return json.dumps(obj, **kwargs)
 
 
 class DeprecatedJSON(ModuleType):
-    def __getattribute__(self, item):
+    def __getattribute__(self, item: str) -> _t.Any:
         import warnings
 
         warnings.warn(

--- a/src/itsdangerous/encoding.py
+++ b/src/itsdangerous/encoding.py
@@ -1,18 +1,23 @@
 import base64
 import string
 import struct
+import typing as _t
 
 from .exc import BadData
 
+_t_str_bytes = _t.Union[str, bytes]
 
-def want_bytes(s, encoding="utf-8", errors="strict"):
+
+def want_bytes(
+    s: _t_str_bytes, encoding: str = "utf-8", errors: str = "strict"
+) -> bytes:
     if isinstance(s, str):
         s = s.encode(encoding, errors)
 
     return s
 
 
-def base64_encode(string):
+def base64_encode(string: _t_str_bytes) -> bytes:
     """Base64 encode a string of bytes or text. The resulting bytes are
     safe to use in URLs.
     """
@@ -20,7 +25,7 @@ def base64_encode(string):
     return base64.urlsafe_b64encode(string).rstrip(b"=")
 
 
-def base64_decode(string):
+def base64_decode(string: _t_str_bytes) -> bytes:
     """Base64 decode a URL-safe string of bytes or text. The result is
     bytes.
     """
@@ -38,12 +43,12 @@ _base64_alphabet = f"{string.ascii_letters}{string.digits}-_=".encode("ascii")
 
 _int64_struct = struct.Struct(">Q")
 _int_to_bytes = _int64_struct.pack
-_bytes_to_int = _int64_struct.unpack
+_bytes_to_int = _t.cast("_t.Callable[[bytes], _t.Tuple[int]]", _int64_struct.unpack)
 
 
-def int_to_bytes(num):
+def int_to_bytes(num: int) -> bytes:
     return _int_to_bytes(num).lstrip(b"\x00")
 
 
-def bytes_to_int(bytestr):
+def bytes_to_int(bytestr: bytes) -> int:
     return _bytes_to_int(bytestr.rjust(8, b"\x00"))[0]

--- a/src/itsdangerous/exc.py
+++ b/src/itsdangerous/exc.py
@@ -1,3 +1,10 @@
+import typing as _t
+from datetime import datetime
+
+_t_opt_any = _t.Optional[_t.Any]
+_t_opt_exc = _t.Optional[Exception]
+
+
 class BadData(Exception):
     """Raised if bad data of any sort was encountered. This is the base
     for all exceptions that ItsDangerous defines.
@@ -5,20 +12,18 @@ class BadData(Exception):
     .. versionadded:: 0.15
     """
 
-    message = None
-
-    def __init__(self, message):
+    def __init__(self, message: str):
         super().__init__(message)
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message
 
 
 class BadSignature(BadData):
     """Raised if a signature does not match."""
 
-    def __init__(self, message, payload=None):
+    def __init__(self, message: str, payload: _t_opt_any = None):
         super().__init__(message)
 
         #: The payload that failed the signature test. In some
@@ -26,7 +31,7 @@ class BadSignature(BadData):
         #: you know it was tampered with.
         #:
         #: .. versionadded:: 0.14
-        self.payload = payload
+        self.payload: _t_opt_any = payload
 
 
 class BadTimeSignature(BadSignature):
@@ -34,7 +39,12 @@ class BadTimeSignature(BadSignature):
     of :class:`BadSignature`.
     """
 
-    def __init__(self, message, payload=None, date_signed=None):
+    def __init__(
+        self,
+        message: str,
+        payload: _t_opt_any = None,
+        date_signed: _t.Optional[datetime] = None,
+    ):
         super().__init__(message, payload)
 
         #: If the signature expired this exposes the date of when the
@@ -62,16 +72,22 @@ class BadHeader(BadSignature):
     .. versionadded:: 0.24
     """
 
-    def __init__(self, message, payload=None, header=None, original_error=None):
+    def __init__(
+        self,
+        message: str,
+        payload: _t_opt_any = None,
+        header: _t_opt_any = None,
+        original_error: _t_opt_exc = None,
+    ):
         super().__init__(message, payload)
 
         #: If the header is actually available but just malformed it
         #: might be stored here.
-        self.header = header
+        self.header: _t_opt_any = header
 
         #: If available, the error that indicates why the payload was
         #: not valid. This might be ``None``.
-        self.original_error = original_error
+        self.original_error: _t_opt_exc = original_error
 
 
 class BadPayload(BadData):
@@ -83,9 +99,9 @@ class BadPayload(BadData):
     .. versionadded:: 0.15
     """
 
-    def __init__(self, message, original_error=None):
+    def __init__(self, message: str, original_error: _t_opt_exc = None):
         super().__init__(message)
 
         #: If available, the error that indicates why the payload was
         #: not valid. This might be ``None``.
-        self.original_error = original_error
+        self.original_error: _t_opt_exc = original_error

--- a/src/itsdangerous/signer.py
+++ b/src/itsdangerous/signer.py
@@ -1,5 +1,6 @@
 import hashlib
 import hmac
+import typing as _t
 
 from .encoding import _base64_alphabet
 from .encoding import base64_decode
@@ -7,17 +8,21 @@ from .encoding import base64_encode
 from .encoding import want_bytes
 from .exc import BadSignature
 
+_t_str_bytes = _t.Union[str, bytes]
+_t_opt_str_bytes = _t.Optional[_t_str_bytes]
+_t_secret_key = _t.Union[_t.Iterable[_t_str_bytes], _t_str_bytes]
+
 
 class SigningAlgorithm:
     """Subclasses must implement :meth:`get_signature` to provide
     signature generation functionality.
     """
 
-    def get_signature(self, key, value):
+    def get_signature(self, key: bytes, value: bytes) -> bytes:
         """Returns the signature for the given key and value."""
         raise NotImplementedError()
 
-    def verify_signature(self, key, value, sig):
+    def verify_signature(self, key: bytes, value: bytes, sig: bytes) -> bool:
         """Verifies the given signature matches the expected
         signature.
         """
@@ -29,7 +34,7 @@ class NoneAlgorithm(SigningAlgorithm):
     returns an empty signature.
     """
 
-    def get_signature(self, key, value):
+    def get_signature(self, key: bytes, value: bytes) -> bytes:
         return b""
 
 
@@ -39,17 +44,24 @@ class HMACAlgorithm(SigningAlgorithm):
     #: The digest method to use with the MAC algorithm. This defaults to
     #: SHA1, but can be changed to any other function in the hashlib
     #: module.
-    default_digest_method = staticmethod(hashlib.sha1)
+    default_digest_method: _t.Any = staticmethod(hashlib.sha1)
 
-    def __init__(self, digest_method=None):
+    def __init__(self, digest_method: _t.Any = None):
         if digest_method is None:
             digest_method = self.default_digest_method
 
-        self.digest_method = digest_method
+        self.digest_method: _t.Any = digest_method
 
-    def get_signature(self, key, value):
+    def get_signature(self, key: bytes, value: bytes) -> bytes:
         mac = hmac.new(key, msg=value, digestmod=self.digest_method)
         return mac.digest()
+
+
+def _make_keys_list(secret_key: _t_secret_key) -> _t.List[bytes]:
+    if isinstance(secret_key, (str, bytes)):
+        return [want_bytes(secret_key)]
+
+    return [want_bytes(s) for s in secret_key]
 
 
 class Signer:
@@ -96,36 +108,31 @@ class Signer:
     #: doesn't apply when used intermediately in HMAC.
     #:
     #: .. versionadded:: 0.14
-    default_digest_method = staticmethod(hashlib.sha1)
+    default_digest_method: _t.Any = staticmethod(hashlib.sha1)
 
     #: The default scheme to use to derive the signing key from the
     #: secret key and salt. The default is ``django-concat``. Possible
     #: values are ``concat``, ``django-concat``, and ``hmac``.
     #:
     #: .. versionadded:: 0.14
-    default_key_derivation = "django-concat"
+    default_key_derivation: str = "django-concat"
 
     def __init__(
         self,
-        secret_key,
-        salt=None,
-        sep=".",
-        key_derivation=None,
-        digest_method=None,
-        algorithm=None,
+        secret_key: _t_secret_key,
+        salt: _t_str_bytes = b"itsdangerous.Signer",
+        sep: _t_str_bytes = b".",
+        key_derivation: _t.Optional[str] = None,
+        digest_method: _t.Optional[_t.Any] = None,
+        algorithm: _t.Optional[SigningAlgorithm] = None,
     ):
-        if isinstance(secret_key, list):
-            secret_keys = [want_bytes(s) for s in secret_key]
-        else:
-            secret_keys = [want_bytes(secret_key)]
-
         #: The list of secret keys to try for verifying signatures, from
         #: oldest to newest. The newest (last) key is used for signing.
         #:
         #: This allows a key rotation system to keep a list of allowed
         #: keys and remove expired ones.
-        self.secret_keys = secret_keys
-        self.sep = want_bytes(sep)
+        self.secret_keys: _t.List[bytes] = _make_keys_list(secret_key)
+        self.sep: bytes = want_bytes(sep)
 
         if self.sep in _base64_alphabet:
             raise ValueError(
@@ -134,31 +141,31 @@ class Signer:
                 " digits, and '-_=' must not be used."
             )
 
-        self.salt = "itsdangerous.Signer" if salt is None else salt
+        self.salt: bytes = want_bytes(salt)
 
         if key_derivation is None:
             key_derivation = self.default_key_derivation
 
-        self.key_derivation = key_derivation
+        self.key_derivation: str = key_derivation
 
         if digest_method is None:
             digest_method = self.default_digest_method
 
-        self.digest_method = digest_method
+        self.digest_method: _t.Any = digest_method
 
         if algorithm is None:
             algorithm = HMACAlgorithm(self.digest_method)
 
-        self.algorithm = algorithm
+        self.algorithm: SigningAlgorithm = algorithm
 
     @property
-    def secret_key(self):
+    def secret_key(self) -> bytes:
         """The newest (last) entry in the :attr:`secret_keys` list. This
         is for compatibility from before key rotation support was added.
         """
         return self.secret_keys[-1]
 
-    def derive_key(self, secret_key=None):
+    def derive_key(self, secret_key: _t_opt_str_bytes = None) -> bytes:
         """This method is called to derive the key. The default key
         derivation choices can be overridden here. Key derivation is not
         intended to be used as a security method to make a complex key
@@ -176,38 +183,41 @@ class Signer:
         else:
             secret_key = want_bytes(secret_key)
 
-        salt = want_bytes(self.salt)
-
         if self.key_derivation == "concat":
-            return self.digest_method(salt + secret_key).digest()
+            return _t.cast(bytes, self.digest_method(self.salt + secret_key).digest())
         elif self.key_derivation == "django-concat":
-            return self.digest_method(salt + b"signer" + secret_key).digest()
+            return _t.cast(
+                bytes, self.digest_method(self.salt + b"signer" + secret_key).digest()
+            )
         elif self.key_derivation == "hmac":
             mac = hmac.new(secret_key, digestmod=self.digest_method)
-            mac.update(salt)
+            mac.update(self.salt)
             return mac.digest()
         elif self.key_derivation == "none":
             return secret_key
         else:
             raise TypeError("Unknown key derivation method")
 
-    def get_signature(self, value):
+    def get_signature(self, value: _t_str_bytes) -> bytes:
         """Returns the signature for the given value."""
         value = want_bytes(value)
         key = self.derive_key()
         sig = self.algorithm.get_signature(key, value)
         return base64_encode(sig)
 
-    def sign(self, value):
+    def sign(self, value: _t_str_bytes) -> bytes:
         """Signs the given string."""
-        return want_bytes(value) + want_bytes(self.sep) + self.get_signature(value)
+        value = want_bytes(value)
+        return value + self.sep + self.get_signature(value)
 
-    def verify_signature(self, value, sig):
+    def verify_signature(self, value: _t_str_bytes, sig: _t_str_bytes) -> bool:
         """Verifies the signature for the given value."""
         try:
             sig = base64_decode(sig)
         except Exception:
             return False
+
+        value = want_bytes(value)
 
         for secret_key in reversed(self.secret_keys):
             key = self.derive_key(secret_key)
@@ -217,22 +227,21 @@ class Signer:
 
         return False
 
-    def unsign(self, signed_value):
+    def unsign(self, signed_value: _t_str_bytes) -> bytes:
         """Unsigns the given string."""
         signed_value = want_bytes(signed_value)
-        sep = want_bytes(self.sep)
 
-        if sep not in signed_value:
+        if self.sep not in signed_value:
             raise BadSignature(f"No {self.sep!r} found in value")
 
-        value, sig = signed_value.rsplit(sep, 1)
+        value, sig = signed_value.rsplit(self.sep, 1)
 
         if self.verify_signature(value, sig):
             return value
 
         raise BadSignature(f"Signature {sig!r} does not match", payload=value)
 
-    def validate(self, signed_value):
+    def validate(self, signed_value: _t_str_bytes) -> bool:
         """Only validates the given signed value. Returns ``True`` if
         the signature exists and is valid.
         """

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -1,4 +1,6 @@
 import time
+import typing
+import typing as _t
 from datetime import datetime
 from datetime import timezone
 
@@ -13,6 +15,10 @@ from .exc import SignatureExpired
 from .serializer import Serializer
 from .signer import Signer
 
+_t_str_bytes = _t.Union[str, bytes]
+_t_opt_str_bytes = _t.Optional[_t_str_bytes]
+_t_opt_int = _t.Optional[int]
+
 
 class TimestampSigner(Signer):
     """Works like the regular :class:`.Signer` but also records the time
@@ -21,13 +27,13 @@ class TimestampSigner(Signer):
     unsigning failed because the signature is expired.
     """
 
-    def get_timestamp(self):
+    def get_timestamp(self) -> int:
         """Returns the current timestamp. The function must return an
         integer.
         """
         return int(time.time())
 
-    def timestamp_to_datetime(self, ts):
+    def timestamp_to_datetime(self, ts: int) -> datetime:
         """Convert the timestamp from :meth:`get_timestamp` into an
         aware :class`datetime.datetime` in UTC.
 
@@ -37,7 +43,7 @@ class TimestampSigner(Signer):
         """
         return datetime.fromtimestamp(ts, tz=timezone.utc)
 
-    def sign(self, value):
+    def sign(self, value: _t_str_bytes) -> bytes:
         """Signs the given string and also attaches time information."""
         value = want_bytes(value)
         timestamp = base64_encode(int_to_bytes(self.get_timestamp()))
@@ -45,7 +51,33 @@ class TimestampSigner(Signer):
         value = value + sep + timestamp
         return value + sep + self.get_signature(value)
 
-    def unsign(self, value, max_age=None, return_timestamp=False):
+    # Ignore overlapping signatures check, return_timestamp is the only
+    # parameter that affects the return type.
+
+    @typing.overload
+    def unsign(  # type: ignore
+        self,
+        signed_value: _t_str_bytes,
+        max_age: _t_opt_int = None,
+        return_timestamp: "_t.Literal[False]" = False,
+    ) -> bytes:
+        ...
+
+    @typing.overload
+    def unsign(
+        self,
+        signed_value: _t_str_bytes,
+        max_age: _t_opt_int = None,
+        return_timestamp: "_t.Literal[True]" = True,
+    ) -> _t.Tuple[bytes, datetime]:
+        ...
+
+    def unsign(
+        self,
+        signed_value: _t_str_bytes,
+        max_age: _t_opt_int = None,
+        return_timestamp: bool = False,
+    ) -> _t.Union[_t.Tuple[bytes, datetime], bytes]:
         """Works like the regular :meth:`.Signer.unsign` but can also
         validate the time. See the base docstring of the class for
         the general behavior. If ``return_timestamp`` is ``True`` the
@@ -57,7 +89,7 @@ class TimestampSigner(Signer):
             in UTC rather than a naive ``datetime`` assumed to be UTC.
         """
         try:
-            result = super().unsign(value)
+            result = super().unsign(signed_value)
             sig_error = None
         except BadSignature as e:
             sig_error = e
@@ -76,50 +108,52 @@ class TimestampSigner(Signer):
 
             raise BadTimeSignature("timestamp missing", payload=result)
 
-        value, timestamp = result.rsplit(sep, 1)
+        value, ts_bytes = result.rsplit(sep, 1)
+        ts_int: _t_opt_int = None
+        ts_dt: _t.Optional[datetime] = None
 
         try:
-            timestamp = bytes_to_int(base64_decode(timestamp))
+            ts_int = bytes_to_int(base64_decode(ts_bytes))
         except Exception:
-            timestamp = None
+            pass
 
         # Signature is *not* okay. Raise a proper error now that we have
         # split the value and the timestamp.
         if sig_error is not None:
-            if timestamp is not None:
-                timestamp = self.timestamp_to_datetime(timestamp)
+            if ts_int is not None:
+                ts_dt = self.timestamp_to_datetime(ts_int)
 
-            raise BadTimeSignature(str(sig_error), payload=value, date_signed=timestamp)
+            raise BadTimeSignature(str(sig_error), payload=value, date_signed=ts_dt)
 
         # Signature was okay but the timestamp is actually not there or
         # malformed. Should not happen, but we handle it anyway.
-        if timestamp is None:
+        if ts_int is None:
             raise BadTimeSignature("Malformed timestamp", payload=value)
 
         # Check timestamp is not older than max_age
         if max_age is not None:
-            age = self.get_timestamp() - timestamp
+            age = self.get_timestamp() - ts_int
 
             if age > max_age:
                 raise SignatureExpired(
                     f"Signature age {age} > {max_age} seconds",
                     payload=value,
-                    date_signed=self.timestamp_to_datetime(timestamp),
+                    date_signed=self.timestamp_to_datetime(ts_int),
                 )
 
             if age < 0:
                 raise SignatureExpired(
                     f"Signature age {age} < 0 seconds",
                     payload=value,
-                    date_signed=self.timestamp_to_datetime(timestamp),
+                    date_signed=self.timestamp_to_datetime(ts_int),
                 )
 
         if return_timestamp:
-            return value, self.timestamp_to_datetime(timestamp)
+            return value, self.timestamp_to_datetime(ts_int)
 
         return value
 
-    def validate(self, signed_value, max_age=None):
+    def validate(self, signed_value: _t_str_bytes, max_age: _t_opt_int = None) -> bool:
         """Only validates the given signed value. Returns ``True`` if
         the signature exists and is valid."""
         try:
@@ -134,9 +168,23 @@ class TimedSerializer(Serializer):
     :class:`.Signer`.
     """
 
-    default_signer = TimestampSigner
+    default_signer: _t.Type[TimestampSigner] = TimestampSigner
 
-    def loads(self, s, max_age=None, return_timestamp=False, salt=None):
+    def iter_unsigners(
+        self, salt: _t_opt_str_bytes = None
+    ) -> _t.Iterator[TimestampSigner]:
+        return _t.cast("_t.Iterator[TimestampSigner]", super().iter_unsigners(salt))
+
+    # TODO: Signature is incompatible because parameters were added
+    #  before salt.
+
+    def loads(  # type: ignore
+        self,
+        s: _t_str_bytes,
+        max_age: _t_opt_int = None,
+        return_timestamp: bool = False,
+        salt: _t_opt_str_bytes = None,
+    ) -> _t.Any:
         """Reverse of :meth:`dumps`, raises :exc:`.BadSignature` if the
         signature validation fails. If a ``max_age`` is provided it will
         ensure the signature is not older than that time in seconds. In
@@ -149,24 +197,28 @@ class TimedSerializer(Serializer):
 
         for signer in self.iter_unsigners(salt):
             try:
-                base64d, timestamp = signer.unsign(s, max_age, return_timestamp=True)
+                base64d, timestamp = signer.unsign(
+                    s, max_age=max_age, return_timestamp=True
+                )
                 payload = self.load_payload(base64d)
 
                 if return_timestamp:
                     return payload, timestamp
 
                 return payload
-            # If we get a signature expired it means we could read the
-            # signature but it's invalid.  In that case we do not want to
-            # try the next signer.
             except SignatureExpired:
+                # The signature was unsigned successfully but was
+                # expired. Do not try the next signer.
                 raise
             except BadSignature as err:
                 last_exception = err
 
-        raise last_exception
+        raise _t.cast(BadSignature, last_exception)
 
-    def loads_unsafe(self, s, max_age=None, salt=None):
-        load_kwargs = {"max_age": max_age}
-        load_payload_kwargs = {}
-        return self._loads_unsafe_impl(s, salt, load_kwargs, load_payload_kwargs)
+    def loads_unsafe(  # type: ignore
+        self,
+        s: _t_str_bytes,
+        max_age: _t_opt_int = None,
+        salt: _t_opt_str_bytes = None,
+    ) -> _t.Tuple[bool, _t.Any]:
+        return self._loads_unsafe_impl(s, salt, load_kwargs={"max_age": max_age})

--- a/src/itsdangerous/url_safe.py
+++ b/src/itsdangerous/url_safe.py
@@ -1,3 +1,4 @@
+import typing as _t
 import zlib
 
 from ._json import _CompactJSON
@@ -8,7 +9,7 @@ from .serializer import Serializer
 from .timed import TimedSerializer
 
 
-class URLSafeSerializerMixin:
+class URLSafeSerializerMixin(Serializer):
     """Mixed in with a regular serializer it will attempt to zlib
     compress the string to make it shorter if necessary. It will also
     base64 encode the string so that it can safely be placed in a URL.
@@ -16,7 +17,13 @@ class URLSafeSerializerMixin:
 
     default_serializer = _CompactJSON
 
-    def load_payload(self, payload, *args, **kwargs):
+    def load_payload(
+        self,
+        payload: bytes,
+        *args: _t.Any,
+        serializer: _t.Optional[_t.Any] = None,
+        **kwargs: _t.Any,
+    ) -> _t.Any:
         decompress = False
 
         if payload.startswith(b"."):
@@ -42,7 +49,7 @@ class URLSafeSerializerMixin:
 
         return super().load_payload(json, *args, **kwargs)
 
-    def dump_payload(self, obj):
+    def dump_payload(self, obj: _t.Any) -> bytes:
         json = super().dump_payload(obj)
         is_compressed = False
         compressed = zlib.compress(json)

--- a/tests/test_itsdangerous/test_jws.py
+++ b/tests/test_itsdangerous/test_jws.py
@@ -22,10 +22,10 @@ class TestJWSSerializer(TestSerializer):
 
         return factory
 
-    test_signer_cls = None
-    test_signer_kwargs = None
-    test_fallback_signers = None
-    test_iter_unsigners = None
+    test_signer_cls = None  # type: ignore
+    test_signer_kwargs = None  # type: ignore
+    test_fallback_signers = None  # type: ignore
+    test_iter_unsigners = None  # type: ignore
 
     @pytest.mark.parametrize("algorithm_name", ("HS256", "HS384", "HS512", "none"))
     def test_algorithm(self, serializer_factory, algorithm_name):

--- a/tests/test_itsdangerous/test_signer.py
+++ b/tests/test_itsdangerous/test_signer.py
@@ -106,4 +106,4 @@ def test_abstract_algorithm():
     alg = SigningAlgorithm()
 
     with pytest.raises(NotImplementedError):
-        alg.get_signature("a", "b")
+        alg.get_signature(b"a", b"b")

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -6,9 +6,9 @@ from functools import partial
 import pytest
 from freezegun import freeze_time
 
-from itsdangerous import Signer
 from itsdangerous.exc import BadTimeSignature
 from itsdangerous.exc import SignatureExpired
+from itsdangerous.signer import Signer
 from itsdangerous.timed import TimedSerializer
 from itsdangerous.timed import TimestampSigner
 from test_itsdangerous.test_serializer import TestSerializer

--- a/tests/test_itsdangerous/test_url_safe.py
+++ b/tests/test_itsdangerous/test_url_safe.py
@@ -2,8 +2,8 @@ from functools import partial
 
 import pytest
 
-from itsdangerous import URLSafeSerializer
-from itsdangerous import URLSafeTimedSerializer
+from itsdangerous.url_safe import URLSafeSerializer
+from itsdangerous.url_safe import URLSafeTimedSerializer
 from test_itsdangerous.test_serializer import TestSerializer
 from test_itsdangerous.test_timed import TestTimedSerializer
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{38,37,36,py3}
     style
+    typing
     docs
 skip_missing_interpreters = true
 
@@ -13,6 +14,12 @@ commands = pytest --tb=short --basetemp={envtmpdir} {posargs}
 deps = pre-commit
 skip_install = true
 commands = pre-commit run --all-files --show-diff-on-failure
+
+[testenv:typing]
+deps =
+    -r requirements/tests.txt
+    mypy
+commands = mypy
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
Implementation notes:

* Didn't import types individually, used `import typing as _t` to shorten things.
* Common types are aliased in a `if TYPE_CHECKING:` block and referenced as string names.
* Only a few types (really just `str_bytes`) were common between modules, didn't bother with a common `_typing` module.
* All generics that aren't in the common block are strings to avoid runtime cost. This won't be necessary once we drop 3.6.
* The `return_timestamp` parameter of `TimestampSigner.unsign` changes the return type. To distinguish these, `@overload` is used, but because the method takes some other optional parameters, many overloads are needed to cover every combination. I added the overloads that matter, as mypy does use that to figure out a type elsewhere, but ignored the finding about incompatible overlap.
* Flake8 has a special case so `@typing.overload` doesn't trigger a redefinition error, but it has to be literally `typing.overload`, `_t.overload` isn't recognized. So had to ignore that Flake8 finding.
* Mypy doesn't allow assignment of modules or classes for `Protocol`, so `Serializer.serializer` has the `Any` type for now. See https://github.com/python/mypy/issues/5018.

Findings and future work:

* `TimedSerializer.loads` and `loads_unsafe` have incompatible signatures with `Serializer.loads` because extra parameters were added before the `salt` parameter. This violates the Liskov substitution principle, and should probably be migrated with `*args` and a deprecation warning at some point. I added a `TODO` in the code.
* Between removing Python 2 compat helpers and adding typing, I'm more convinced that accepting `bytes` and `str` interchangeably everywhere is not good. Python 3 emphasizes understanding the boundary between the two.

  Because pretty much every single point in the ItsDangerous API accepts either, `want_bytes` is called over and over again, even where it's redundant because an earlier function already called it. I already moved `wants_bytes` around to get a few spots that were missed. This isn't a huge deal in ItsDangerous, but it's probably hurting performance in Werkzeug where it happens much more often.

  It's still probably useful to accept both as the data passed to `Serializer.loads`, `Signer.sign`, and `Singer.unsign`, since you might be signing either bytes or text, and received data to be loaded might be bytes or text (ASGI vs WSGI, for example). Everything else should probably be bytes only since that's how they're used.

cc @pgjones