### PR TITLE
allow salt=None again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Unreleased
 
 -   Mark top-level names as exported so type checking understands
     imports in user projects. :pr:`240`
+-   The ``salt`` argument to ``Serializer`` and ``Signer`` can be
+    ``None`` again. :issue:`237`
 
 
 Version 2.0.0

--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -89,7 +89,7 @@ class Serializer:
     def __init__(
         self,
         secret_key: _t_secret_key,
-        salt: _t_str_bytes = b"itsdangerous",
+        salt: _t_opt_str_bytes = b"itsdangerous",
         serializer: _t.Any = None,
         serializer_kwargs: _t_opt_kwargs = None,
         signer: _t.Optional[_t_signer] = None,
@@ -102,7 +102,12 @@ class Serializer:
         #: This allows a key rotation system to keep a list of allowed
         #: keys and remove expired ones.
         self.secret_keys: _t.List[bytes] = _make_keys_list(secret_key)
-        self.salt: bytes = want_bytes(salt)
+
+        if salt is not None:
+            salt = want_bytes(salt)
+            # if salt is None then the signer's default is used
+
+        self.salt = salt
 
         if serializer is None:
             serializer = self.default_serializer

--- a/src/itsdangerous/signer.py
+++ b/src/itsdangerous/signer.py
@@ -120,7 +120,7 @@ class Signer:
     def __init__(
         self,
         secret_key: _t_secret_key,
-        salt: _t_str_bytes = b"itsdangerous.Signer",
+        salt: _t_opt_str_bytes = b"itsdangerous.Signer",
         sep: _t_str_bytes = b".",
         key_derivation: _t.Optional[str] = None,
         digest_method: _t.Optional[_t.Any] = None,
@@ -141,7 +141,12 @@ class Signer:
                 " digits, and '-_=' must not be used."
             )
 
-        self.salt: bytes = want_bytes(salt)
+        if salt is not None:
+            salt = want_bytes(salt)
+        else:
+            salt = b"itsdangerous.Signer"
+
+        self.salt = salt
 
         if key_derivation is None:
             key_derivation = self.default_key_derivation


### PR DESCRIPTION
Was thinking of deprecating this, but the (deprecated) JWS subclasses used the same pattern of setting their default to `None` to get the parent's behavior, so I'll just leave it at that for now.

- fixes #237 

<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
