### PR TITLE
Add the ability to specify the timestamp used when signing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 Version 2.1.0
 -------------
 
-Unreleased
+-   Add the ability to specify the timestamp used when
+    signing. :pr:`250`
 
 
 Version 2.0.2

--- a/docs/timed.rst
+++ b/docs/timed.rst
@@ -21,6 +21,17 @@ than a given age.
       ...
     itsdangerous.exc.SignatureExpired: Signature age 15 > 5 seconds
 
+If desired, for example when testing code that triggers on
+SignatureExpired errors you can specify the timestamp used when
+signing,
+
+.. code-block:: python
+
+    from itsdangerous import TimestampSigner
+    ts = int(datetime(2021, 7, 29, 10, 45).timestamp())
+    s = TimestampSigner('secret-key', timestamp=ts)
+    string = s.sign('foo')
+
 .. autoclass:: TimestampSigner
     :members:
 

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -83,6 +83,12 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
 
         assert isinstance(exc_info.value.date_signed, datetime)
 
+    def test_specific_timestamp(self, signer):
+        ts = datetime(2021, 7, 29, 10, 45, tzinfo=timezone.utc)
+        other = TimestampSigner("secret-key", timestamp=int(ts.timestamp()))
+        signed = other.sign("value")
+        assert signer.unsign(signed, return_timestamp=True) == (b"value", ts)
+
 
 class TestTimedSerializer(FreezeMixin, TestSerializer):
     @pytest.fixture()


### PR DESCRIPTION
This makes it much easier to test, as it is now possible to create
signed tokens that have a specific age. It also allows for tokens to
be created for a specific expiry time in mind, for example by creating
a token that has a midnight timestamp and a max age of 24 hours.

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
