### PR TITLE
Fix Issue Tracker link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Links
 -   Changes: https://itsdangerous.palletsprojects.com/changes/
 -   PyPI Releases: https://pypi.org/project/ItsDangerous/
 -   Source Code: https://github.com/pallets/itsdangerous/
--   Issue Tracker: https://github.com/pallets/itsdnagerous/issues/
+-   Issue Tracker: https://github.com/pallets/itsdangerous/issues/
 -   Website: https://palletsprojects.com/p/itsdangerous/
 -   Twitter: https://twitter.com/PalletsTeam
 -   Chat: https://discord.gg/pallets


### PR DESCRIPTION
Fixes a small typo in the Issue Tracker link in the README. I also dropped the trailing slash since it doesn't seem necessary.