### PR TITLE
Catch unhandled ValueError from future timestamp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 2.1.1
 
 Unreleased
 
+-   Handle date overflow in timed unsign. :pr:`296`
+
 
 Version 2.1.0
 -------------

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -38,7 +38,8 @@ class TimestampSigner(Signer):
 
     def timestamp_to_datetime(self, ts: int) -> datetime:
         """Convert the timestamp from :meth:`get_timestamp` into an
-        aware :class`datetime.datetime` in UTC.
+        aware :class`datetime.datetime` in UTC. Raises :exc:`.ValueError`
+        if the timestamp is too far in the past or future for Python.
 
         .. versionchanged:: 2.0
             The timestamp is returned as a timezone-aware ``datetime``
@@ -124,7 +125,12 @@ class TimestampSigner(Signer):
         # split the value and the timestamp.
         if sig_error is not None:
             if ts_int is not None:
-                ts_dt = self.timestamp_to_datetime(ts_int)
+                try:
+                    ts_dt = self.timestamp_to_datetime(ts_int)
+                except ValueError as exc:
+                    raise BadTimeSignature(
+                        "Malformed timestamp", payload=value
+                    ) from exc
 
             raise BadTimeSignature(str(sig_error), payload=value, date_signed=ts_dt)
 

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -38,8 +38,7 @@ class TimestampSigner(Signer):
 
     def timestamp_to_datetime(self, ts: int) -> datetime:
         """Convert the timestamp from :meth:`get_timestamp` into an
-        aware :class`datetime.datetime` in UTC. Raises :exc:`.ValueError`
-        if the timestamp is too far in the past or future for Python.
+        aware :class`datetime.datetime` in UTC.
 
         .. versionchanged:: 2.0
             The timestamp is returned as a timezone-aware ``datetime``
@@ -127,7 +126,8 @@ class TimestampSigner(Signer):
             if ts_int is not None:
                 try:
                     ts_dt = self.timestamp_to_datetime(ts_int)
-                except ValueError as exc:
+                except (ValueError, OSError) as exc:
+                    # Windows raises OSError
                     raise BadTimeSignature(
                         "Malformed timestamp", payload=value
                     ) from exc

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -59,6 +60,18 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
     def test_malformed_timestamp(self, signer):
         other = Signer("secret-key")
         signed = other.sign(b"value.____________")
+
+        with pytest.raises(BadTimeSignature) as exc_info:
+            signer.unsign(signed)
+
+        assert "Malformed" in str(exc_info.value)
+        assert exc_info.value.date_signed is None
+
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Freezegun Invalid argument occurs on Windows"
+    )
+    def test_malformed_future_timestamp(self, signer):
+        signed = b"value.TgPVoaGhoQ.AGBfQ6G6cr07byTRt0zAdPljHOY"
 
         with pytest.raises(BadTimeSignature) as exc_info:
             signer.unsign(signed)

--- a/tests/test_itsdangerous/test_timed.py
+++ b/tests/test_itsdangerous/test_timed.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -67,9 +66,6 @@ class TestTimestampSigner(FreezeMixin, TestSigner):
         assert "Malformed" in str(exc_info.value)
         assert exc_info.value.date_signed is None
 
-    @pytest.mark.skipif(
-        sys.platform == "win32", reason="Freezegun Invalid argument occurs on Windows"
-    )
     def test_malformed_future_timestamp(self, signer):
         signed = b"value.TgPVoaGhoQ.AGBfQ6G6cr07byTRt0zAdPljHOY"
 


### PR DESCRIPTION
Fixes unhandled `ValueError` when timestamp is too far in the future:

```
Traceback (most recent call last):
  File "venv/lib/python3.8/site-packages/flask/app.py", line 2072, in wsgi_app
    ctx.push()
  File "venv/lib/python3.8/site-packages/flask/ctx.py", line 404, in push
    self.session = session_interface.open_session(self.app, self.request)
  File "venv/lib/python3.8/site-packages/flask/sessions.py", line 361, in open_session
    data = s.loads(val, max_age=max_age)
  File "venv/lib/python3.8/site-packages/itsdangerous/timed.py", line 203, in loads
    base64d, timestamp = signer.unsign(
  File "venv/lib/python3.8/site-packages/itsdangerous/timed.py", line 127, in unsign
    ts_dt = self.timestamp_to_datetime(ts_int)
  File "venv/lib/python3.8/site-packages/itsdangerous/timed.py", line 47, in timestamp_to_datetime
    return datetime.fromtimestamp(ts, tz=timezone.utc)
ValueError: year 5365471 is out of range
```


<!--
Ensure each step in CONTRIBUTING.rst is complete by adding an "x" to
each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update relevant docs, in the docs folder and in code.
- [x] Add an entry in `CHANGES.rst` summarizing the change and linking to the issue.
- [x] Add `.. versionchanged::` entries in any relevant code docs.
- [x] Run `pre-commit` hooks and fix any issues.
- [x] Run `pytest` and `tox`, no tests failed.
