### PR TITLE
ignore flake8-bugbear B905

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,8 @@ ignore =
     E722
     # bin op line break, invalid
     W503
+    # zip with strict=, requires python >= 3.10
+    B905
 # up to 88 allowed by bugbear B950
 max-line-length = 80
 per-file-ignores =


### PR DESCRIPTION
Ignore flake8-bugbear B905, which requires Python>=3.10.
