### PR TITLE
improve typing

### DIFF
--- a/src/itsdangerous/_json.py
+++ b/src/itsdangerous/_json.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import json as _json
-import typing as _t
+import typing as t
 
 
 class _CompactJSON:
     """Wrapper around json module that strips whitespace."""
 
     @staticmethod
-    def loads(payload: _t.Union[str, bytes]) -> _t.Any:
+    def loads(payload: str | bytes) -> t.Any:
         return _json.loads(payload)
 
     @staticmethod
-    def dumps(obj: _t.Any, **kwargs: _t.Any) -> str:
+    def dumps(obj: t.Any, **kwargs: t.Any) -> str:
         kwargs.setdefault("ensure_ascii", False)
         kwargs.setdefault("separators", (",", ":"))
         return _json.dumps(obj, **kwargs)

--- a/src/itsdangerous/encoding.py
+++ b/src/itsdangerous/encoding.py
@@ -1,15 +1,15 @@
+from __future__ import annotations
+
 import base64
 import string
 import struct
-import typing as _t
+import typing as t
 
 from .exc import BadData
 
-_t_str_bytes = _t.Union[str, bytes]
-
 
 def want_bytes(
-    s: _t_str_bytes, encoding: str = "utf-8", errors: str = "strict"
+    s: str | bytes, encoding: str = "utf-8", errors: str = "strict"
 ) -> bytes:
     if isinstance(s, str):
         s = s.encode(encoding, errors)
@@ -17,7 +17,7 @@ def want_bytes(
     return s
 
 
-def base64_encode(string: _t_str_bytes) -> bytes:
+def base64_encode(string: str | bytes) -> bytes:
     """Base64 encode a string of bytes or text. The resulting bytes are
     safe to use in URLs.
     """
@@ -25,7 +25,7 @@ def base64_encode(string: _t_str_bytes) -> bytes:
     return base64.urlsafe_b64encode(string).rstrip(b"=")
 
 
-def base64_decode(string: _t_str_bytes) -> bytes:
+def base64_decode(string: str | bytes) -> bytes:
     """Base64 decode a URL-safe string of bytes or text. The result is
     bytes.
     """
@@ -43,7 +43,7 @@ _base64_alphabet = f"{string.ascii_letters}{string.digits}-_=".encode("ascii")
 
 _int64_struct = struct.Struct(">Q")
 _int_to_bytes = _int64_struct.pack
-_bytes_to_int = _t.cast("_t.Callable[[bytes], _t.Tuple[int]]", _int64_struct.unpack)
+_bytes_to_int = t.cast("t.Callable[[bytes], tuple[int]]", _int64_struct.unpack)
 
 
 def int_to_bytes(num: int) -> bytes:

--- a/src/itsdangerous/exc.py
+++ b/src/itsdangerous/exc.py
@@ -1,8 +1,7 @@
-import typing as _t
-from datetime import datetime
+from __future__ import annotations
 
-_t_opt_any = _t.Optional[_t.Any]
-_t_opt_exc = _t.Optional[Exception]
+import typing as t
+from datetime import datetime
 
 
 class BadData(Exception):
@@ -23,7 +22,7 @@ class BadData(Exception):
 class BadSignature(BadData):
     """Raised if a signature does not match."""
 
-    def __init__(self, message: str, payload: _t_opt_any = None):
+    def __init__(self, message: str, payload: t.Any | None = None):
         super().__init__(message)
 
         #: The payload that failed the signature test. In some
@@ -31,7 +30,7 @@ class BadSignature(BadData):
         #: you know it was tampered with.
         #:
         #: .. versionadded:: 0.14
-        self.payload: _t_opt_any = payload
+        self.payload: t.Any | None = payload
 
 
 class BadTimeSignature(BadSignature):
@@ -42,8 +41,8 @@ class BadTimeSignature(BadSignature):
     def __init__(
         self,
         message: str,
-        payload: _t_opt_any = None,
-        date_signed: _t.Optional[datetime] = None,
+        payload: t.Any | None = None,
+        date_signed: datetime | None = None,
     ):
         super().__init__(message, payload)
 
@@ -75,19 +74,19 @@ class BadHeader(BadSignature):
     def __init__(
         self,
         message: str,
-        payload: _t_opt_any = None,
-        header: _t_opt_any = None,
-        original_error: _t_opt_exc = None,
+        payload: t.Any | None = None,
+        header: t.Any | None = None,
+        original_error: Exception | None = None,
     ):
         super().__init__(message, payload)
 
         #: If the header is actually available but just malformed it
         #: might be stored here.
-        self.header: _t_opt_any = header
+        self.header: t.Any | None = header
 
         #: If available, the error that indicates why the payload was
         #: not valid. This might be ``None``.
-        self.original_error: _t_opt_exc = original_error
+        self.original_error: Exception | None = original_error
 
 
 class BadPayload(BadData):
@@ -99,9 +98,9 @@ class BadPayload(BadData):
     .. versionadded:: 0.15
     """
 
-    def __init__(self, message: str, original_error: _t_opt_exc = None):
+    def __init__(self, message: str, original_error: Exception | None = None):
         super().__init__(message)
 
         #: If available, the error that indicates why the payload was
         #: not valid. This might be ``None``.
-        self.original_error: _t_opt_exc = original_error
+        self.original_error: Exception | None = original_error

--- a/src/itsdangerous/signer.py
+++ b/src/itsdangerous/signer.py
@@ -1,16 +1,15 @@
+from __future__ import annotations
+
+import collections.abc as cabc
 import hashlib
 import hmac
-import typing as _t
+import typing as t
 
 from .encoding import _base64_alphabet
 from .encoding import base64_decode
 from .encoding import base64_encode
 from .encoding import want_bytes
 from .exc import BadSignature
-
-_t_str_bytes = _t.Union[str, bytes]
-_t_opt_str_bytes = _t.Optional[_t_str_bytes]
-_t_secret_key = _t.Union[_t.Iterable[_t_str_bytes], _t_str_bytes]
 
 
 class SigningAlgorithm:
@@ -44,24 +43,26 @@ class HMACAlgorithm(SigningAlgorithm):
     #: The digest method to use with the MAC algorithm. This defaults to
     #: SHA1, but can be changed to any other function in the hashlib
     #: module.
-    default_digest_method: _t.Any = staticmethod(hashlib.sha1)
+    default_digest_method: t.Any = staticmethod(hashlib.sha1)
 
-    def __init__(self, digest_method: _t.Any = None):
+    def __init__(self, digest_method: t.Any = None):
         if digest_method is None:
             digest_method = self.default_digest_method
 
-        self.digest_method: _t.Any = digest_method
+        self.digest_method: t.Any = digest_method
 
     def get_signature(self, key: bytes, value: bytes) -> bytes:
         mac = hmac.new(key, msg=value, digestmod=self.digest_method)
         return mac.digest()
 
 
-def _make_keys_list(secret_key: _t_secret_key) -> _t.List[bytes]:
+def _make_keys_list(
+    secret_key: str | bytes | cabc.Iterable[str] | cabc.Iterable[bytes],
+) -> list[bytes]:
     if isinstance(secret_key, (str, bytes)):
         return [want_bytes(secret_key)]
 
-    return [want_bytes(s) for s in secret_key]
+    return [want_bytes(s) for s in secret_key]  # pyright: ignore
 
 
 class Signer:
@@ -108,7 +109,7 @@ class Signer:
     #: doesn't apply when used intermediately in HMAC.
     #:
     #: .. versionadded:: 0.14
-    default_digest_method: _t.Any = staticmethod(hashlib.sha1)
+    default_digest_method: t.Any = staticmethod(hashlib.sha1)
 
     #: The default scheme to use to derive the signing key from the
     #: secret key and salt. The default is ``django-concat``. Possible
@@ -119,19 +120,19 @@ class Signer:
 
     def __init__(
         self,
-        secret_key: _t_secret_key,
-        salt: _t_opt_str_bytes = b"itsdangerous.Signer",
-        sep: _t_str_bytes = b".",
-        key_derivation: _t.Optional[str] = None,
-        digest_method: _t.Optional[_t.Any] = None,
-        algorithm: _t.Optional[SigningAlgorithm] = None,
+        secret_key: str | bytes | cabc.Iterable[str] | cabc.Iterable[bytes],
+        salt: str | bytes | None = b"itsdangerous.Signer",
+        sep: str | bytes = b".",
+        key_derivation: str | None = None,
+        digest_method: t.Any | None = None,
+        algorithm: SigningAlgorithm | None = None,
     ):
         #: The list of secret keys to try for verifying signatures, from
         #: oldest to newest. The newest (last) key is used for signing.
         #:
         #: This allows a key rotation system to keep a list of allowed
         #: keys and remove expired ones.
-        self.secret_keys: _t.List[bytes] = _make_keys_list(secret_key)
+        self.secret_keys: list[bytes] = _make_keys_list(secret_key)
         self.sep: bytes = want_bytes(sep)
 
         if self.sep in _base64_alphabet:
@@ -156,7 +157,7 @@ class Signer:
         if digest_method is None:
             digest_method = self.default_digest_method
 
-        self.digest_method: _t.Any = digest_method
+        self.digest_method: t.Any = digest_method
 
         if algorithm is None:
             algorithm = HMACAlgorithm(self.digest_method)
@@ -170,7 +171,7 @@ class Signer:
         """
         return self.secret_keys[-1]
 
-    def derive_key(self, secret_key: _t_opt_str_bytes = None) -> bytes:
+    def derive_key(self, secret_key: str | bytes | None = None) -> bytes:
         """This method is called to derive the key. The default key
         derivation choices can be overridden here. Key derivation is not
         intended to be used as a security method to make a complex key
@@ -189,9 +190,9 @@ class Signer:
             secret_key = want_bytes(secret_key)
 
         if self.key_derivation == "concat":
-            return _t.cast(bytes, self.digest_method(self.salt + secret_key).digest())
+            return t.cast(bytes, self.digest_method(self.salt + secret_key).digest())
         elif self.key_derivation == "django-concat":
-            return _t.cast(
+            return t.cast(
                 bytes, self.digest_method(self.salt + b"signer" + secret_key).digest()
             )
         elif self.key_derivation == "hmac":
@@ -203,19 +204,19 @@ class Signer:
         else:
             raise TypeError("Unknown key derivation method")
 
-    def get_signature(self, value: _t_str_bytes) -> bytes:
+    def get_signature(self, value: str | bytes) -> bytes:
         """Returns the signature for the given value."""
         value = want_bytes(value)
         key = self.derive_key()
         sig = self.algorithm.get_signature(key, value)
         return base64_encode(sig)
 
-    def sign(self, value: _t_str_bytes) -> bytes:
+    def sign(self, value: str | bytes) -> bytes:
         """Signs the given string."""
         value = want_bytes(value)
         return value + self.sep + self.get_signature(value)
 
-    def verify_signature(self, value: _t_str_bytes, sig: _t_str_bytes) -> bool:
+    def verify_signature(self, value: str | bytes, sig: str | bytes) -> bool:
         """Verifies the signature for the given value."""
         try:
             sig = base64_decode(sig)
@@ -232,7 +233,7 @@ class Signer:
 
         return False
 
-    def unsign(self, signed_value: _t_str_bytes) -> bytes:
+    def unsign(self, signed_value: str | bytes) -> bytes:
         """Unsigns the given string."""
         signed_value = want_bytes(signed_value)
 
@@ -246,7 +247,7 @@ class Signer:
 
         raise BadSignature(f"Signature {sig!r} does not match", payload=value)
 
-    def validate(self, signed_value: _t_str_bytes) -> bool:
+    def validate(self, signed_value: str | bytes) -> bool:
         """Only validates the given signed value. Returns ``True`` if
         the signature exists and is valid.
         """

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
+import collections.abc as cabc
 import time
-import typing
-import typing as _t
+import typing as t
 from datetime import datetime
 from datetime import timezone
 
@@ -14,13 +16,6 @@ from .exc import BadTimeSignature
 from .exc import SignatureExpired
 from .serializer import Serializer
 from .signer import Signer
-
-_t_str_bytes = _t.Union[str, bytes]
-_t_opt_str_bytes = _t.Optional[_t_str_bytes]
-_t_opt_int = _t.Optional[int]
-
-if _t.TYPE_CHECKING:
-    import typing_extensions as _te
 
 
 class TimestampSigner(Signer):
@@ -46,7 +41,7 @@ class TimestampSigner(Signer):
         """
         return datetime.fromtimestamp(ts, tz=timezone.utc)
 
-    def sign(self, value: _t_str_bytes) -> bytes:
+    def sign(self, value: str | bytes) -> bytes:
         """Signs the given string and also attaches time information."""
         value = want_bytes(value)
         timestamp = base64_encode(int_to_bytes(self.get_timestamp()))
@@ -57,28 +52,28 @@ class TimestampSigner(Signer):
     # Ignore overlapping signatures check, return_timestamp is the only
     # parameter that affects the return type.
 
-    @typing.overload
-    def unsign(  # type: ignore
+    @t.overload
+    def unsign(  # type: ignore[overload-overlap]
         self,
-        signed_value: _t_str_bytes,
-        max_age: _t_opt_int = None,
-        return_timestamp: "_te.Literal[False]" = False,
+        signed_value: str | bytes,
+        max_age: int | None = None,
+        return_timestamp: t.Literal[False] = False,
     ) -> bytes: ...
 
-    @typing.overload
+    @t.overload
     def unsign(
         self,
-        signed_value: _t_str_bytes,
-        max_age: _t_opt_int = None,
-        return_timestamp: "_te.Literal[True]" = True,
-    ) -> _t.Tuple[bytes, datetime]: ...
+        signed_value: str | bytes,
+        max_age: int | None = None,
+        return_timestamp: t.Literal[True] = True,
+    ) -> tuple[bytes, datetime]: ...
 
     def unsign(
         self,
-        signed_value: _t_str_bytes,
-        max_age: _t_opt_int = None,
+        signed_value: str | bytes,
+        max_age: int | None = None,
         return_timestamp: bool = False,
-    ) -> _t.Union[_t.Tuple[bytes, datetime], bytes]:
+    ) -> tuple[bytes, datetime] | bytes:
         """Works like the regular :meth:`.Signer.unsign` but can also
         validate the time. See the base docstring of the class for
         the general behavior. If ``return_timestamp`` is ``True`` the
@@ -110,8 +105,8 @@ class TimestampSigner(Signer):
             raise BadTimeSignature("timestamp missing", payload=result)
 
         value, ts_bytes = result.rsplit(sep, 1)
-        ts_int: _t_opt_int = None
-        ts_dt: _t.Optional[datetime] = None
+        ts_int: int | None = None
+        ts_dt: datetime | None = None
 
         try:
             ts_int = bytes_to_int(base64_decode(ts_bytes))
@@ -161,7 +156,7 @@ class TimestampSigner(Signer):
 
         return value
 
-    def validate(self, signed_value: _t_str_bytes, max_age: _t_opt_int = None) -> bool:
+    def validate(self, signed_value: str | bytes, max_age: int | None = None) -> bool:
         """Only validates the given signed value. Returns ``True`` if
         the signature exists and is valid."""
         try:
@@ -176,23 +171,23 @@ class TimedSerializer(Serializer):
     :class:`.Signer`.
     """
 
-    default_signer: _t.Type[TimestampSigner] = TimestampSigner
+    default_signer: type[TimestampSigner] = TimestampSigner
 
     def iter_unsigners(
-        self, salt: _t_opt_str_bytes = None
-    ) -> _t.Iterator[TimestampSigner]:
-        return _t.cast("_t.Iterator[TimestampSigner]", super().iter_unsigners(salt))
+        self, salt: str | bytes | None = None
+    ) -> cabc.Iterator[TimestampSigner]:
+        return t.cast("cabc.Iterator[TimestampSigner]", super().iter_unsigners(salt))
 
     # TODO: Signature is incompatible because parameters were added
     #  before salt.
 
-    def loads(  # type: ignore
+    def loads(  # type: ignore[override]
         self,
-        s: _t_str_bytes,
-        max_age: _t_opt_int = None,
+        s: str | bytes,
+        max_age: int | None = None,
         return_timestamp: bool = False,
-        salt: _t_opt_str_bytes = None,
-    ) -> _t.Any:
+        salt: str | bytes | None = None,
+    ) -> t.Any:
         """Reverse of :meth:`dumps`, raises :exc:`.BadSignature` if the
         signature validation fails. If a ``max_age`` is provided it will
         ensure the signature is not older than that time in seconds. In
@@ -221,12 +216,12 @@ class TimedSerializer(Serializer):
             except BadSignature as err:
                 last_exception = err
 
-        raise _t.cast(BadSignature, last_exception)
+        raise t.cast(BadSignature, last_exception)
 
-    def loads_unsafe(  # type: ignore
+    def loads_unsafe(  # type: ignore[override]
         self,
-        s: _t_str_bytes,
-        max_age: _t_opt_int = None,
-        salt: _t_opt_str_bytes = None,
-    ) -> _t.Tuple[bool, _t.Any]:
+        s: str | bytes,
+        max_age: int | None = None,
+        salt: str | bytes | None = None,
+    ) -> tuple[bool, t.Any]:
         return self._loads_unsafe_impl(s, salt, load_kwargs={"max_age": max_age})

--- a/src/itsdangerous/url_safe.py
+++ b/src/itsdangerous/url_safe.py
@@ -1,4 +1,6 @@
-import typing as _t
+from __future__ import annotations
+
+import typing as t
 import zlib
 
 from ._json import _CompactJSON
@@ -20,10 +22,10 @@ class URLSafeSerializerMixin(Serializer):
     def load_payload(
         self,
         payload: bytes,
-        *args: _t.Any,
-        serializer: _t.Optional[_t.Any] = None,
-        **kwargs: _t.Any,
-    ) -> _t.Any:
+        *args: t.Any,
+        serializer: t.Any | None = None,
+        **kwargs: t.Any,
+    ) -> t.Any:
         decompress = False
 
         if payload.startswith(b"."):
@@ -49,7 +51,7 @@ class URLSafeSerializerMixin(Serializer):
 
         return super().load_payload(json, *args, **kwargs)
 
-    def dump_payload(self, obj: _t.Any) -> bytes:
+    def dump_payload(self, obj: t.Any) -> bytes:
         json = super().dump_payload(obj)
         is_compressed = False
         compressed = zlib.compress(json)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,10 @@ commands = pre-commit run --all-files
 
 [testenv:typing]
 deps = -r requirements/typing.txt
-commands = mypy
+commands =
+    mypy
+    pyright
+    pyright --verifytypes itsdangerous --ignoreexternal
 
 [testenv:docs]
 deps = -r requirements/docs.txt


### PR DESCRIPTION
* use deferred annotations, enabling modern syntax
* use `collections.abc`
* check with pyright
* verify exported API with `pyright --verifytypes`
* use specific ignores (for mypy)
