### PR TITLE
type `Serializer` as generic

### DIFF
--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -17,6 +17,8 @@ from .exc import SignatureExpired
 from .serializer import Serializer
 from .signer import Signer
 
+_TAnyStr = t.TypeVar("_TAnyStr", str, bytes, covariant=True)
+
 
 class TimestampSigner(Signer):
     """Works like the regular :class:`.Signer` but also records the time
@@ -166,7 +168,7 @@ class TimestampSigner(Signer):
             return False
 
 
-class TimedSerializer(Serializer):
+class TimedSerializer(Serializer[_TAnyStr]):
     """Uses :class:`TimestampSigner` instead of the default
     :class:`.Signer`.
     """

--- a/src/itsdangerous/url_safe.py
+++ b/src/itsdangerous/url_safe.py
@@ -7,17 +7,18 @@ from ._json import _CompactJSON
 from .encoding import base64_decode
 from .encoding import base64_encode
 from .exc import BadPayload
+from .serializer import _PDataSerializer
 from .serializer import Serializer
 from .timed import TimedSerializer
 
 
-class URLSafeSerializerMixin(Serializer):
+class URLSafeSerializerMixin(Serializer[str]):
     """Mixed in with a regular serializer it will attempt to zlib
     compress the string to make it shorter if necessary. It will also
     base64 encode the string so that it can safely be placed in a URL.
     """
 
-    default_serializer = _CompactJSON
+    default_serializer: _PDataSerializer[str] = _CompactJSON
 
     def load_payload(
         self,
@@ -68,14 +69,14 @@ class URLSafeSerializerMixin(Serializer):
         return base64d
 
 
-class URLSafeSerializer(URLSafeSerializerMixin, Serializer):
+class URLSafeSerializer(URLSafeSerializerMixin, Serializer[str]):
     """Works like :class:`.Serializer` but dumps and loads into a URL
     safe string consisting of the upper and lowercase character of the
     alphabet as well as ``'_'``, ``'-'`` and ``'.'``.
     """
 
 
-class URLSafeTimedSerializer(URLSafeSerializerMixin, TimedSerializer):
+class URLSafeTimedSerializer(URLSafeSerializerMixin, TimedSerializer[str]):
     """Works like :class:`.TimedSerializer` but dumps and loads into a
     URL safe string consisting of the upper and lowercase character of
     the alphabet as well as ``'_'``, ``'-'`` and ``'.'``.


### PR DESCRIPTION
`Serializer` now takes one generic parameter, either `str` or `bytes`, to define what `dumps` returns rather than a `str | bytes` union.

The `default_serializer` attribute and `serializer` argument are a generic protocol with the same parameter. The protocol requires an object that has a `loads` method and a `dumps` method that returns the appropriate type.

`URLSafeSerizlizer` is typed to always return `str`. This makes it more convenient as the user code no longer needs to do extra work to satisfy the type checker.

```python
s = URLSafeSerializer()
data = s.dumps(...)
```

fixes #347 