### PR TITLE
support FIPS builds without SHA-1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,9 @@ Unreleased
     By default it is ``Serializer[str]`` and ``dumps`` returns a ``str``. If a
     different ``serializer`` argument is given, it will try to infer the return
     type of its ``dumps`` method. :issue:`347`
+-   The default ``hashlib.sha1`` may not be available in FIPS builds. Don't
+    access it at import time so the developer has time to change the default.
+    :issue:`375`
 
 
 Version 2.1.2

--- a/src/itsdangerous/signer.py
+++ b/src/itsdangerous/signer.py
@@ -37,13 +37,21 @@ class NoneAlgorithm(SigningAlgorithm):
         return b""
 
 
+def _lazy_sha1(string: bytes = b"") -> t.Any:
+    """Don't access ``hashlib.sha1`` until runtime. FIPS builds may not include
+    SHA-1, in which case the import and use as a default would fail before the
+    developer can configure something else.
+    """
+    return hashlib.sha1(string)
+
+
 class HMACAlgorithm(SigningAlgorithm):
     """Provides signature generation using HMACs."""
 
     #: The digest method to use with the MAC algorithm. This defaults to
     #: SHA1, but can be changed to any other function in the hashlib
     #: module.
-    default_digest_method: t.Any = staticmethod(hashlib.sha1)
+    default_digest_method: t.Any = staticmethod(_lazy_sha1)
 
     def __init__(self, digest_method: t.Any = None):
         if digest_method is None:
@@ -109,7 +117,7 @@ class Signer:
     #: doesn't apply when used intermediately in HMAC.
     #:
     #: .. versionadded:: 0.14
-    default_digest_method: t.Any = staticmethod(hashlib.sha1)
+    default_digest_method: t.Any = staticmethod(_lazy_sha1)
 
     #: The default scheme to use to derive the signing key from the
     #: secret key and salt. The default is ``django-concat``. Possible

--- a/tests/test_itsdangerous/test_serializer.py
+++ b/tests/test_itsdangerous/test_serializer.py
@@ -14,6 +14,7 @@ import pytest
 from itsdangerous.exc import BadPayload
 from itsdangerous.exc import BadSignature
 from itsdangerous.serializer import Serializer
+from itsdangerous.signer import _lazy_sha1
 from itsdangerous.signer import Signer
 
 
@@ -177,7 +178,7 @@ class TestSerializer:
         )
 
         unsigners = serializer.iter_unsigners()
-        assert next(unsigners).digest_method == hashlib.sha1
+        assert next(unsigners).digest_method == _lazy_sha1
 
         for signer in unsigners:
             assert signer.digest_method == hashlib.sha256


### PR DESCRIPTION
`hashlib.sha1` may not be available in some FIPS builds that go beyond what FIPS requires into what it recommends. Apparently some RedHat containers do this. We don't want to change the default, but now it is accessed lazily so that it fails at runtime rather than at import time. This way, the developer has time after importing to change the default before using.

fixes #375
