### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "itsdangerous"
 version = "2.2.0"
 description = "Safely pass data to untrusted environments and back."
 readme = "README.md"
-license = { file = "LICENSE.txt" }
+license = { text = "BSD-3-Clause" }
 maintainers = [{ name = "Pallets", email = "contact@palletsprojects.com" }]
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
[PEP 639](https://peps.python.org/pep-0639/) recommends the use of SPDX license identifiers.

At the moment the `license` key is ignored by `flit`, see https://github.com/pypa/flit/issues/525. However, it's still possible to replace it now. Once the support in flit is added, the value will be used automatically.

_At some point, the table will need be be changed to just a string for full PEP 639 compliance. That requires support for it first though. The change is also pretty simple._
```diff
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
```