### PR TITLE
Pylint alerts corrections as part of an intervention experiment 398

### DIFF
--- a/src/itsdangerous/signer.py
+++ b/src/itsdangerous/signer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import collections.abc as cabc
 import hashlib
 import hmac
@@ -9,6 +10,7 @@ from .encoding import _base64_alphabet
 from .encoding import base64_decode
 from .encoding import base64_encode
 from .encoding import want_bytes
+from .exc import BadData
 from .exc import BadSignature
 
 
@@ -228,7 +230,7 @@ class Signer:
         """Verifies the signature for the given value."""
         try:
             sig = base64_decode(sig)
-        except Exception:
+        except (BadData, base64.binascii.Error):
             return False
 
         value = want_bytes(value)

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 import collections.abc as cabc
 import time
 import typing as t
@@ -113,7 +112,7 @@ class TimestampSigner(Signer):
 
         try:
             ts_int = bytes_to_int(base64_decode(ts_bytes))
-        except (BadData, base64.binascii.Error):
+        except BadData:
             pass
 
         # Signature is *not* okay. Raise a proper error now that we have

--- a/src/itsdangerous/timed.py
+++ b/src/itsdangerous/timed.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import collections.abc as cabc
 import time
 import typing as t
@@ -11,6 +12,7 @@ from .encoding import base64_encode
 from .encoding import bytes_to_int
 from .encoding import int_to_bytes
 from .encoding import want_bytes
+from .exc import BadData
 from .exc import BadSignature
 from .exc import BadTimeSignature
 from .exc import SignatureExpired
@@ -111,7 +113,7 @@ class TimestampSigner(Signer):
 
         try:
             ts_int = bytes_to_int(base64_decode(ts_bytes))
-        except Exception:
+        except (BadData, base64.binascii.Error):
             pass
 
         # Signature is *not* okay. Raise a proper error now that we have


### PR DESCRIPTION
Makes the interventions describe in [intervention issue](https://github.com/pallets/itsdangerous/issues/398).
The experiment is described [here](https://github.com/evidencebp/pylint-intervention/).

Each intervention was done in a dedicated commit with a message explaining it.
However, note that the original code and fix are very similar.
