### PR TITLE
AI spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ loading a token.
 Here's how you could generate a token for transmitting a user's id and
 name between web requests.
 
+itsdangerous has two main layers: a **Signer** that HMAC-signs raw bytes to detect tampering, and a **Serializer** that wraps a Signer to let you sign arbitrary Python objects (dicts, lists, etc.) by serializing them first. Most users want the Serializer (or one of its subclasses like `URLSafeSerializer`); reach for the Signer directly only when you're already working with bytes.
+
 ```python
 from itsdangerous import URLSafeSerializer
 auth_s = URLSafeSerializer("secret key", "auth")

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,8 +53,8 @@ Table of Contents
 .. toctree::
 
     concepts
-    serializer
     signer
+    serializer
     exceptions
     timed
     url_safe

--- a/docs/serializer.rst
+++ b/docs/serializer.rst
@@ -41,9 +41,11 @@ payload if the signature check failed. This has to be done with extra
 care because at that point you know that someone tampered with your data
 but it might be useful for debugging purposes.
 
+This example uses :class:`~itsdangerous.url_safe.URLSafeSerializer` so the token is safe to pass in a URL or cookie, but the error handling pattern is the same for any serializer class.
+
 .. code-block:: python
 
-    from itsdangerous.serializer import Serializer
+    from itsdangerous.url_safe import URLSafeSerializer
     from itsdangerous.exc import BadSignature, BadData
 
     s = URLSafeSerializer("secret-key")

--- a/docs/timed.rst
+++ b/docs/timed.rst
@@ -8,6 +8,8 @@ If you want to expire signatures you can use the
 signs it. On unsigning you can validate that the timestamp is not older
 than a given age.
 
+:class:`TimestampSigner` signs raw bytes and embeds a timestamp — use it when you're already working with bytes and need expiry. :class:`TimedSerializer` wraps :class:`TimestampSigner` to handle arbitrary Python objects such as dicts and lists — use it when you want to sign structured data with an expiry. In general, if you're not already working with raw bytes, reach for :class:`TimedSerializer`.
+
 .. code-block:: python
 
     from itsdangerous import TimestampSigner


### PR DESCRIPTION
## What this changes and why

### The path problem (primary)

Before this PR, a new user arriving at the itsdangerous docs faced two structural problems that compounded each other:

1. **Wrong toctree order.** The docs listed `serializer` before `signer`, so users read about the higher-level `Serializer` wrapper *before* they had any mental model of the `Signer` primitive it is built on. The conceptual dependency was backwards — you can't reason about what a `Serializer` does for you if you don't yet understand what a `Signer` is.

2. **README dropped users into the most-specific subclass first.** The opening code example used `URLSafeSerializer` with no framing, so the very first mental model a new user built was of a specific, convenience subclass rather than the core abstraction. When they then hit the concepts page — which assumes you understand the `Signer`/`Serializer` distinction — they had no foundation to stand on.

Together, these two issues meant the natural reading order actively worked against understanding.

### What changed structurally

- **Toctree reordered to `signer → serializer`.** The docs now read in dependency order: you learn the primitive first, then the wrapper built on top of it.
- **README gains a 2-sentence framing paragraph** before the code example. Users now know what layer they are looking at before they see code, so the first mental model they build is correct rather than upside-down.

### Copy fixes (secondary)

- **`serializer.rst` — broken import in "Responding to Failure" example.** The example used `URLSafeSerializer` but never imported it, which would raise a `NameError` for anyone who tried to run it. Fixed the import, and added a short note explaining why that specific subclass is used in that section.
- **`timed.rst` — no orientation paragraph.** The page launched straight into API details with no explanation of when to reach for `TimestampSigner` vs `TimedSerializer`. Added a short paragraph so readers understand the choice before they start reading the API.