### PR TITLE
AI spam

### DIFF
--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -60,6 +60,8 @@ class Serializer(t.Generic[_TSerialized]):
         :attr:`default_serializer`, which defaults to :mod:`json`.
     :param serializer_kwargs: Keyword arguments to pass when calling
         ``serializer.dumps``.
+    :param deserializer_kwargs: Keyword arguments to pass when calling
+        ``serializer.loads``.
     :param signer: A ``Signer`` class to instantiate when signing data.
         Defaults to :attr:`default_signer`, which defaults to
         :class:`~itsdangerous.signer.Signer`.
@@ -111,6 +113,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None = b"itsdangerous",
         serializer: None | _PDataSerializer[str] = None,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -127,6 +130,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None,
         serializer: _PDataSerializer[bytes],
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -144,6 +148,7 @@ class Serializer(t.Generic[_TSerialized]):
         *,
         serializer: _PDataSerializer[bytes],
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -162,6 +167,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None,
         serializer: t.Any,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -179,6 +185,7 @@ class Serializer(t.Generic[_TSerialized]):
         *,
         serializer: t.Any,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -193,6 +200,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None = b"itsdangerous",
         serializer: t.Any | None = None,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -232,6 +240,7 @@ class Serializer(t.Generic[_TSerialized]):
             dict[str, t.Any] | tuple[type[Signer], dict[str, t.Any]] | type[Signer]
         ] = fallback_signers
         self.serializer_kwargs: dict[str, t.Any] = serializer_kwargs or {}
+        self.deserializer_kwargs: dict[str, t.Any] = deserializer_kwargs or {}
 
     @property
     def secret_key(self) -> bytes:
@@ -258,9 +267,13 @@ class Serializer(t.Generic[_TSerialized]):
 
         try:
             if is_text:
-                return use_serializer.loads(payload.decode("utf-8"))  # type: ignore[arg-type]
+                return use_serializer.loads(  # type: ignore[arg-type]
+                    payload.decode("utf-8"), **self.deserializer_kwargs
+                )
 
-            return use_serializer.loads(payload)  # type: ignore[arg-type]
+            return use_serializer.loads(  # type: ignore[arg-type]
+                payload, **self.deserializer_kwargs
+            )
         except Exception as e:
             raise BadPayload(
                 "Could not load the payload because an exception"

--- a/tests/test_itsdangerous/test_serializer.py
+++ b/tests/test_itsdangerous/test_serializer.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import pickle
 from functools import partial
 from io import BytesIO
@@ -151,6 +152,36 @@ class TestSerializer:
             return
 
         assert serializer.loads(serializer.dumps({(): 1})) == {}
+
+    def test_deserializer_kwargs(self, serializer_factory):
+        class KeySerializer:
+            def dumps(self, obj, *, encode_keys=False):
+                if encode_keys:
+                    obj = {f"int:{key}": value for key, value in obj.items()}
+
+                return json.dumps(obj)
+
+            def loads(self, payload, *, decode_keys=False):
+                obj = json.loads(payload)
+
+                if decode_keys:
+                    obj = {
+                        int(key.removeprefix("int:")): value
+                        for key, value in obj.items()
+                    }
+
+                return obj
+
+        serializer = serializer_factory(
+            serializer=KeySerializer(),
+            serializer_kwargs={"encode_keys": True},
+            deserializer_kwargs={"decode_keys": True},
+        )
+
+        assert serializer.loads(serializer.dumps({0: "foo", 1: "bar"})) == {
+            0: "foo",
+            1: "bar",
+        }
 
     def test_fallback_signers(self, serializer_factory, value: Any):
         serializer = serializer_factory(signer_kwargs={"digest_method": hashlib.sha256})


### PR DESCRIPTION
Fixes #389.

## Summary
- add `deserializer_kwargs` alongside `serializer_kwargs`
- pass deserializer kwargs only to `serializer.loads` while keeping dump kwargs separate
- add a regression test for serializers that need different dump/load kwargs

## Tests
- RED: `PYTHONPATH=src /opt/miniconda3/bin/python3.13 -m pytest -q tests/test_itsdangerous/test_serializer.py::TestSerializer::test_deserializer_kwargs` failed before the implementation with an unexpected `deserializer_kwargs` argument
- `PYTHONPATH=src /opt/miniconda3/bin/python3.13 -m pytest -q tests/test_itsdangerous/test_serializer.py::TestSerializer::test_deserializer_kwargs tests/test_itsdangerous/test_serializer.py`
- `PYTHONPATH=src /opt/miniconda3/bin/python3.13 -m ruff check src/itsdangerous/serializer.py tests/test_itsdangerous/test_serializer.py`
- `git diff --check`
