### PR TITLE
AI spam

### DIFF
--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -271,9 +271,7 @@ class Serializer(t.Generic[_TSerialized]):
                     payload.decode("utf-8"), **self.deserializer_kwargs
                 )  # type: ignore[arg-type]
 
-            return use_serializer.loads(
-                payload, **self.deserializer_kwargs
-            )  # type: ignore[arg-type]
+            return use_serializer.loads(payload, **self.deserializer_kwargs)  # type: ignore[arg-type]
         except Exception as e:
             raise BadPayload(
                 "Could not load the payload because an exception"

--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -60,6 +60,8 @@ class Serializer(t.Generic[_TSerialized]):
         :attr:`default_serializer`, which defaults to :mod:`json`.
     :param serializer_kwargs: Keyword arguments to pass when calling
         ``serializer.dumps``.
+    :param deserializer_kwargs: Keyword arguments to pass when calling
+        ``serializer.loads``.
     :param signer: A ``Signer`` class to instantiate when signing data.
         Defaults to :attr:`default_signer`, which defaults to
         :class:`~itsdangerous.signer.Signer`.
@@ -111,6 +113,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None = b"itsdangerous",
         serializer: None | _PDataSerializer[str] = None,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -127,6 +130,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None,
         serializer: _PDataSerializer[bytes],
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -144,6 +148,7 @@ class Serializer(t.Generic[_TSerialized]):
         *,
         serializer: _PDataSerializer[bytes],
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -162,6 +167,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None,
         serializer: t.Any,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -179,6 +185,7 @@ class Serializer(t.Generic[_TSerialized]):
         *,
         serializer: t.Any,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -193,6 +200,7 @@ class Serializer(t.Generic[_TSerialized]):
         salt: str | bytes | None = b"itsdangerous",
         serializer: t.Any | None = None,
         serializer_kwargs: dict[str, t.Any] | None = None,
+        deserializer_kwargs: dict[str, t.Any] | None = None,
         signer: type[Signer] | None = None,
         signer_kwargs: dict[str, t.Any] | None = None,
         fallback_signers: list[
@@ -232,6 +240,7 @@ class Serializer(t.Generic[_TSerialized]):
             dict[str, t.Any] | tuple[type[Signer], dict[str, t.Any]] | type[Signer]
         ] = fallback_signers
         self.serializer_kwargs: dict[str, t.Any] = serializer_kwargs or {}
+        self.deserializer_kwargs: dict[str, t.Any] = deserializer_kwargs or {}
 
     @property
     def secret_key(self) -> bytes:
@@ -258,9 +267,13 @@ class Serializer(t.Generic[_TSerialized]):
 
         try:
             if is_text:
-                return use_serializer.loads(payload.decode("utf-8"))  # type: ignore[arg-type]
+                return use_serializer.loads(
+                    payload.decode("utf-8"), **self.deserializer_kwargs
+                )  # type: ignore[arg-type]
 
-            return use_serializer.loads(payload)  # type: ignore[arg-type]
+            return use_serializer.loads(
+                payload, **self.deserializer_kwargs
+            )  # type: ignore[arg-type]
         except Exception as e:
             raise BadPayload(
                 "Could not load the payload because an exception"

--- a/tests/test_itsdangerous/test_serializer.py
+++ b/tests/test_itsdangerous/test_serializer.py
@@ -152,6 +152,24 @@ class TestSerializer:
 
         assert serializer.loads(serializer.dumps({(): 1})) == {}
 
+    def test_deserializer_kwargs(self, serializer_factory):
+        class KwargsSerializer:
+            @staticmethod
+            def dumps(obj, *, dump_value=False):
+                return "dumped" if dump_value else "missing"
+
+            @staticmethod
+            def loads(payload, *, load_value=False):
+                return f"{payload}:{load_value}"
+
+        serializer = serializer_factory(
+            serializer=KwargsSerializer,
+            serializer_kwargs={"dump_value": True},
+            deserializer_kwargs={"load_value": True},
+        )
+
+        assert serializer.loads(serializer.dumps(None)) == "dumped:True"
+
     def test_fallback_signers(self, serializer_factory, value: Any):
         serializer = serializer_factory(signer_kwargs={"digest_method": hashlib.sha256})
         signed = serializer.dumps(value)


### PR DESCRIPTION
﻿## Summary
- add a separate `deserializer_kwargs` option for `serializer.loads`
- keep `serializer_kwargs` scoped to `serializer.dumps`
- add coverage for distinct dump/load serializer keyword arguments

Addresses #389.

## Validation
- `python -m pytest tests/test_itsdangerous/test_serializer.py -q`
- `python -m pytest tests/test_itsdangerous/test_url_safe.py tests/test_itsdangerous/test_timed.py -q`
- `python -m ruff check src/itsdangerous/serializer.py tests/test_itsdangerous/test_serializer.py`
- `git diff --check`

## AI assistance
This change was prepared with assistance from OpenAI Codex.
