### PR TITLE
AI junk

### DIFF
--- a/src/itsdangerous/serializer.py
+++ b/src/itsdangerous/serializer.py
@@ -331,6 +331,13 @@ class Serializer(t.Generic[_TSerialized]):
         """Reverse of :meth:`dumps`. Raises :exc:`.BadSignature` if the
         signature validation fails.
         """
+        if kwargs:
+            unexpected = next(iter(kwargs))
+            raise TypeError(
+                f"{type(self).__name__}.loads() got an unexpected keyword "
+                f"argument {unexpected!r}"
+            )
+
         s = want_bytes(s)
         last_exception = None
 

--- a/tests/test_itsdangerous/test_serializer.py
+++ b/tests/test_itsdangerous/test_serializer.py
@@ -51,6 +51,12 @@ class TestSerializer:
     def test_serializer(self, serializer: Serializer, value: Any):
         assert serializer.loads(serializer.dumps(value)) == value
 
+    def test_unexpected_load_keyword_is_rejected(self, serializer: Serializer):
+        signed = serializer.dumps("value")
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'max_age'"):
+            serializer.loads(signed, max_age=10)
+
     @pytest.mark.parametrize(
         "transform",
         (

--- a/tests/test_itsdangerous/test_serializer.py
+++ b/tests/test_itsdangerous/test_serializer.py
@@ -54,8 +54,10 @@ class TestSerializer:
     def test_unexpected_load_keyword_is_rejected(self, serializer: Serializer):
         signed = serializer.dumps("value")
 
-        with pytest.raises(TypeError, match="unexpected keyword argument 'max_age'"):
-            serializer.loads(signed, max_age=10)
+        with pytest.raises(
+            TypeError, match="unexpected keyword argument 'unsupported'"
+        ):
+            serializer.loads(signed, unsupported=True)
 
     @pytest.mark.parametrize(
         "transform",

--- a/tests/test_itsdangerous/test_url_safe.py
+++ b/tests/test_itsdangerous/test_url_safe.py
@@ -18,6 +18,9 @@ class TestURLSafeSerializer(TestSerializer):
         return request.param
 
     def test_max_age_is_rejected(self, serializer):
+        if isinstance(serializer, URLSafeTimedSerializer):
+            pytest.skip("max_age is supported by timed serializers")
+
         signed = serializer.dumps("value")
 
         with pytest.raises(TypeError, match="unexpected keyword argument 'max_age'"):

--- a/tests/test_itsdangerous/test_url_safe.py
+++ b/tests/test_itsdangerous/test_url_safe.py
@@ -17,6 +17,12 @@ class TestURLSafeSerializer(TestSerializer):
     def value(self, request):
         return request.param
 
+    def test_max_age_is_rejected(self, serializer):
+        signed = serializer.dumps("value")
+
+        with pytest.raises(TypeError, match="unexpected keyword argument 'max_age'"):
+            serializer.loads(signed, max_age=10)
+
 
 class TestURLSafeTimedSerializer(TestURLSafeSerializer, TestTimedSerializer):
     @pytest.fixture()


### PR DESCRIPTION
Fixes pallets/itsdangerous#429.

## Background

`Serializer.loads` accepted arbitrary keyword arguments but silently ignored them. This made a `max_age` argument appear to enable expiration checks when used with `URLSafeSerializer`, even though only timed serializers support it.

## Changes

- Reject unexpected keyword arguments in the base `Serializer.loads` implementation with a standard `TypeError`.
- Add a regression test covering the `max_age` example from the issue.

The existing `salt` argument and timed serializer behavior are unchanged. This is a compatibility correction for previously ignored arguments; callers that passed unsupported keywords must now handle the explicit error.

## Validation

- `PYTHONPATH=src python -m pytest tests/test_itsdangerous/test_serializer.py -q` — 43 passed.
- `ruff format --check src tests` — passed.
- `ruff check src tests` — passed.
- `git diff --check` — passed.

The full test suite was not completed because the local environment does not have the repository's `freezegun` test dependency installed; collection stopped in `test_timed.py` and `test_url_safe.py`.
